### PR TITLE
Fibonacci function, pt.1: if-then-else

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -243,6 +243,20 @@ pub fn store_i32(ctx: &mut Context, local_idx: u32) {
     ctx.regs.release_scratch_gpr(gpr);
 }
 
+pub fn relop_eq_i32(ctx: &mut Context) {
+    let right = pop_i32(ctx);
+    let left = pop_i32(ctx);
+    let result = ctx.regs.take_scratch_gpr();
+    dynasm!(ctx.asm
+        ; xor Rq(result), Rq(result)
+        ; cmp Rd(left), Rd(right)
+        ; sete Rb(result)
+    );
+    push_i32(ctx, result);
+    ctx.regs.release_scratch_gpr(left);
+    ctx.regs.release_scratch_gpr(right);
+}
+
 pub fn prepare_return_value(ctx: &mut Context) {
     let ret_gpr = pop_i32(ctx);
     if ret_gpr != RAX {

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -73,9 +73,9 @@ impl ControlFrame {
     pub fn outgoing_stack_depth(&self) -> StackDepth {
         let mut outgoing_stack_depth = self.stack_depth;
         if self.ty != Type::EmptyBlockType {
-            // If there a return value then increment expected outgoing stack depth value
+            // If there a return value then reserve expected outgoing stack depth value
             // to account for the result value.
-            outgoing_stack_depth.increment();
+            outgoing_stack_depth.reserve(1);
         }
         outgoing_stack_depth
     }

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -133,6 +133,9 @@ pub fn translate(session: &mut CodeGenSession, body: &FunctionBody) -> Result<()
                     define_label(&mut ctx, control_frame.kind.br_destination());
                 }
             }
+            Operator::I32Eq => {
+                relop_eq_i32(&mut ctx);
+            }
             Operator::I32Add => {
                 add_i32(&mut ctx);
             }

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -1,6 +1,8 @@
 use backend::*;
 use error::Error;
-use wasmparser::{FunctionBody, Operator};
+use wasmparser::{FunctionBody, Operator, Type};
+
+// TODO: Use own declared `Type` enum.
 
 /// Type of a control frame.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -10,6 +12,7 @@ enum ControlFrameKind {
     /// Can be used for an implicit function block.
     Block { end_label: Label },
     /// Loop frame (branching to the beginning of block).
+    #[allow(unused)]
     Loop { header: Label },
     /// True-subblock of if expression.
     IfTrue {
@@ -49,18 +52,32 @@ impl ControlFrameKind {
 struct ControlFrame {
     kind: ControlFrameKind,
     /// Boolean which signals whether value stack became polymorphic. Value stack starts in non-polymorphic state and
-	/// becomes polymorphic only after an instruction that never passes control further is executed,
-	/// i.e. `unreachable`, `br` (but not `br_if`!), etc.
+    /// becomes polymorphic only after an instruction that never passes control further is executed,
+    /// i.e. `unreachable`, `br` (but not `br_if`!), etc.
     stack_polymorphic: bool,
-    // TODO: type, stack height, etc
+    /// Relative stack depth at the beginning of the frame.
+    stack_depth: StackDepth,
+    ty: Type,
 }
 
 impl ControlFrame {
-    pub fn new(kind: ControlFrameKind) -> ControlFrame {
+    pub fn new(kind: ControlFrameKind, stack_depth: StackDepth, ty: Type) -> ControlFrame {
         ControlFrame {
             kind,
+            stack_depth,
+            ty,
             stack_polymorphic: false,
         }
+    }
+
+    pub fn outgoing_stack_depth(&self) -> StackDepth {
+        let mut outgoing_stack_depth = self.stack_depth;
+        if self.ty != Type::EmptyBlockType {
+            // If there a return value then increment expected outgoing stack depth value
+            // to account for the result value.
+            outgoing_stack_depth.increment();
+        }
+        outgoing_stack_depth
     }
 
     /// Marks this control frame as reached stack-polymorphic state.
@@ -75,6 +92,7 @@ pub fn translate(session: &mut CodeGenSession, body: &FunctionBody) -> Result<()
     // Assume signature is (i32, i32) -> i32 for now.
     // TODO: Use a real signature
     const ARG_COUNT: u32 = 2;
+    let return_ty = Type::I32;
 
     let mut framesize = ARG_COUNT;
     for local in locals {
@@ -100,6 +118,8 @@ pub fn translate(session: &mut CodeGenSession, body: &FunctionBody) -> Result<()
         ControlFrameKind::Block {
             end_label: epilogue_label,
         },
+        current_stack_depth(&ctx),
+        return_ty,
     ));
 
     for op in operators {
@@ -114,24 +134,63 @@ pub fn translate(session: &mut CodeGenSession, body: &FunctionBody) -> Result<()
             Operator::If { ty } => {
                 let end_label = create_label(&mut ctx);
                 let if_not = create_label(&mut ctx);
-                control_frames.push(ControlFrame::new(
-                    ControlFrameKind::IfTrue {
-                        end_label,
-                        if_not,
-                    },
-                ));
 
-                // TODO: Generate code that pops a value and executes the if_true part if the value
-                // is not equal to zero.
+                pop_and_breq(&mut ctx, if_not);
+
+                control_frames.push(ControlFrame::new(
+                    ControlFrameKind::IfTrue { end_label, if_not },
+                    current_stack_depth(&ctx),
+                    ty,
+                ));
+            }
+            Operator::Else => {
+                match control_frames.pop() {
+                    Some(ControlFrame {
+                        kind: ControlFrameKind::IfTrue { if_not, end_label },
+                        ty,
+                        stack_depth,
+                        ..
+                    }) => {
+                        // Finalize if..else block by jumping to the `end_label`.
+                        br(&mut ctx, end_label);
+
+                        // Define `if_not` label here, so if the corresponding `if` block receives
+                        // 0 it will branch here.
+                        // After that reset stack depth to the value before entering `if` block.
+                        define_label(&mut ctx, if_not);
+                        restore_stack_depth(&mut ctx, stack_depth);
+
+                        // Carry over the `end_label`, so it will be resolved when the corresponding `end`
+                        // is encountered.
+                        //
+                        // Also note that we reset `stack_depth` to the value before entering `if` block.
+                        let mut frame = ControlFrame::new(
+                            ControlFrameKind::IfFalse { end_label },
+                            stack_depth,
+                            ty,
+                        );
+                        control_frames.push(frame);
+                    }
+                    Some(_) => panic!("else expects if block"),
+                    None => panic!("control stack is never empty"),
+                };
             }
             Operator::End => {
                 let control_frame = control_frames.pop().expect("control stack is never empty");
+
                 if !control_frame.kind.is_loop() {
-                    // Branches to a control frame with block type directs control flow to the header of the loop 
+                    // Branches to a control frame with block type directs control flow to the header of the loop
                     // and we don't need to resolve it here. Branching to other control frames always lead
                     // control flow to the corresponding `end`.
                     define_label(&mut ctx, control_frame.kind.br_destination());
                 }
+
+                if let ControlFrameKind::IfTrue { if_not, .. } = control_frame.kind {
+                    // this is `if .. end` construction. Define the `if_not` label here.
+                    define_label(&mut ctx, if_not);
+                }
+
+                restore_stack_depth(&mut ctx, control_frame.outgoing_stack_depth());
             }
             Operator::I32Eq => {
                 relop_eq_i32(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -2,6 +2,73 @@ use backend::*;
 use error::Error;
 use wasmparser::{FunctionBody, Operator};
 
+/// Type of a control frame.
+#[derive(Debug, Copy, Clone, PartialEq)]
+enum ControlFrameKind {
+    /// A regular block frame.
+    ///
+    /// Can be used for an implicit function block.
+    Block { end_label: Label },
+    /// Loop frame (branching to the beginning of block).
+    Loop { header: Label },
+    /// True-subblock of if expression.
+    IfTrue {
+        /// If jump happens inside the if-true block then control will
+        /// land on this label.
+        end_label: Label,
+
+        /// If the condition of the `if` statement is unsatisfied, control
+        /// will land on this label. This label might point to `else` block if it
+        /// exists. Otherwise it equal to `end_label`.
+        if_not: Label,
+    },
+    /// False-subblock of if expression.
+    IfFalse { end_label: Label },
+}
+
+impl ControlFrameKind {
+    /// Returns a label which should be used as a branch destination.
+    fn br_destination(&self) -> Label {
+        match *self {
+            ControlFrameKind::Block { end_label } => end_label,
+            ControlFrameKind::Loop { header } => header,
+            ControlFrameKind::IfTrue { end_label, .. } => end_label,
+            ControlFrameKind::IfFalse { end_label } => end_label,
+        }
+    }
+
+    /// Returns `true` if this block of a loop kind.
+    fn is_loop(&self) -> bool {
+        match *self {
+            ControlFrameKind::Loop { .. } => true,
+            _ => false,
+        }
+    }
+}
+
+struct ControlFrame {
+    kind: ControlFrameKind,
+    /// Boolean which signals whether value stack became polymorphic. Value stack starts in non-polymorphic state and
+	/// becomes polymorphic only after an instruction that never passes control further is executed,
+	/// i.e. `unreachable`, `br` (but not `br_if`!), etc.
+    stack_polymorphic: bool,
+    // TODO: type, stack height, etc
+}
+
+impl ControlFrame {
+    pub fn new(kind: ControlFrameKind) -> ControlFrame {
+        ControlFrame {
+            kind,
+            stack_polymorphic: false,
+        }
+    }
+
+    /// Marks this control frame as reached stack-polymorphic state.
+    pub fn mark_stack_polymorphic(&mut self) {
+        self.stack_polymorphic = true;
+    }
+}
+
 pub fn translate(session: &mut CodeGenSession, body: &FunctionBody) -> Result<(), Error> {
     let locals = body.get_locals_reader()?;
 
@@ -24,24 +91,60 @@ pub fn translate(session: &mut CodeGenSession, body: &FunctionBody) -> Result<()
         copy_incoming_arg(&mut ctx, arg_pos);
     }
 
+    let mut control_frames = Vec::new();
+
+    // Upon entering the function implicit frame for function body is pushed. It has the same
+    // result type as the function itself. Branching to it is equivalent to returning from the function.
+    let epilogue_label = create_label(&mut ctx);
+    control_frames.push(ControlFrame::new(
+        ControlFrameKind::Block {
+            end_label: epilogue_label,
+        },
+    ));
+
     for op in operators {
         match op? {
+            Operator::Unreachable => {
+                control_frames
+                    .last_mut()
+                    .expect("control stack is never empty")
+                    .mark_stack_polymorphic();
+                trap(&mut ctx);
+            }
+            Operator::If { ty } => {
+                let end_label = create_label(&mut ctx);
+                let if_not = create_label(&mut ctx);
+                control_frames.push(ControlFrame::new(
+                    ControlFrameKind::IfTrue {
+                        end_label,
+                        if_not,
+                    },
+                ));
+
+                // TODO: Generate code that pops a value and executes the if_true part if the value
+                // is not equal to zero.
+            }
+            Operator::End => {
+                let control_frame = control_frames.pop().expect("control stack is never empty");
+                if !control_frame.kind.is_loop() {
+                    // Branches to a control frame with block type directs control flow to the header of the loop 
+                    // and we don't need to resolve it here. Branching to other control frames always lead
+                    // control flow to the corresponding `end`.
+                    define_label(&mut ctx, control_frame.kind.br_destination());
+                }
+            }
             Operator::I32Add => {
                 add_i32(&mut ctx);
             }
             Operator::GetLocal { local_index } => {
                 get_local_i32(&mut ctx, local_index);
             }
-            Operator::End => {
-                // TODO: This is super naive and makes a lot of unfounded assumptions 
-                // but will do for the start.
-                prepare_return_value(&mut ctx);
-            }
             _ => {
-                unsupported_opcode(&mut ctx);
+                trap(&mut ctx);
             }
         }
     }
+    prepare_return_value(&mut ctx);
     epilogue(&mut ctx);
 
     Ok(())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,4 +31,26 @@ fn adds() {
     }
 }
 
+#[test]
+fn relop_eq() {
+    const CASES: &[(usize, usize, usize)] = &[
+        (0, 0, 1),
+        (0, 1, 0),
+        (1, 0, 0),
+        (1, 1, 1),
+        (1312, 1, 0),
+        (1312, 1312, 1),
+    ];
+
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32) (i32.eq (get_local 0) (get_local 1)))
+)
+    "#;
+
+    for (a, b, expected) in CASES {
+        assert_eq!(execute_wat(code, *a, *b), *expected);
+    }
+}
+
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,4 +53,56 @@ fn relop_eq() {
     }
 }
 
+#[test]
+fn if_then_else() {
+    const CASES: &[(usize, usize, usize)] = &[
+        (0, 1, 1),
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 1),
+        (1312, 1, 1),
+        (1312, 1312, 1312),
+    ];
+
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32)
+    (if (result i32)
+      (i32.eq
+        (get_local 0)
+        (get_local 1)
+      )
+      (then (get_local 0))
+      (else (get_local 1))
+    )
+  )
+)
+    "#;
+
+    for (a, b, expected) in CASES {
+        assert_eq!(execute_wat(code, *a, *b), *expected, "{}, {}", a, b);
+    }
+}
+
+#[test]
+fn if_without_result() {
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32)
+    (if
+      (i32.eq
+        (get_local 0)
+        (get_local 1)
+      )
+      (then (unreachable))
+    )
+
+    (get_local 0)
+  )
+)
+    "#;
+
+    assert_eq!(execute_wat(code, 2, 3), 2);
+}
+
 // TODO: Add a test that checks argument passing via the stack.


### PR DESCRIPTION
This PR implements the first step in #3: if-then-else construction.
It also implements `i32.eq` (from #4). It should be enough of `i32.eq` alone to implement unsigned `fib` function.
