### PR TITLE
Fibonacci function, pt.2: basic calls

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -151,7 +151,7 @@ impl CodeGenSession {
         {
             let func_start = &mut self.func_defs[func_idx as usize];
 
-            // At this point we now the exact start address of this function. Save it
+            // At this point we know the exact start address of this function. Save it
             // and define dynamic label at this location.
             func_start.offset = Some(self.assembler.offset());
             self.assembler.dynamic_label(func_start.label);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -261,13 +261,21 @@ pub fn get_local_i32(ctx: &mut Context, local_idx: u32) {
     push_i32(ctx, gpr);
 }
 
-pub fn store_i32(ctx: &mut Context, local_idx: u32) {
+pub fn set_local_i32(ctx: &mut Context, local_idx: u32) {
     let gpr = pop_i32(ctx);
     let offset = sp_relative_offset(ctx, local_idx);
     dynasm!(ctx.asm
         ; mov [rsp + offset], Rq(gpr)
     );
     ctx.regs.release_scratch_gpr(gpr);
+}
+
+pub fn literal_i32(ctx: &mut Context, imm: i32) {
+    let gpr = ctx.regs.take_scratch_gpr();
+    dynasm!(ctx.asm
+        ; mov Rd(gpr), imm
+    );
+    push_i32(ctx, gpr);
 }
 
 pub fn relop_eq_i32(ctx: &mut Context) {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -361,11 +361,20 @@ pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
     }
 }
 
-pub fn call_direct(ctx: &mut Context, index: u32) {
+pub fn call_direct(ctx: &mut Context, index: u32, return_arity: u32) {
+    assert!(return_arity == 0 || return_arity == 1);
+
     let label = &ctx.func_starts[index as usize].1;
     dynasm!(ctx.asm
         ; call =>*label
     );
+
+    if return_arity == 1 {
+        dynasm!(ctx.asm
+            ; push rax
+        );
+        ctx.sp_depth.reserve(1);
+    }
 }
 
 pub fn prologue(ctx: &mut Context, stack_slots: u32) {

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -224,6 +224,7 @@ pub fn translate(
                 let callee_ty = translation_ctx.func_type(function_index);
 
                 // TODO: this implementation assumes that this function is locally defined.
+                // TODO: guarantee 16-byte alignment for calls as required by x86-64 ABI
 
                 pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
                 call_direct(&mut ctx, function_index, callee_ty.returns.len() as u32);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -222,13 +222,11 @@ pub fn translate(
             }
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
-                assert!(callee_ty.returns.len() == 0, "is not supported");
 
-                // TODO: ensure that this function is locally defined
-                // We would like to support imported functions at some point
+                // TODO: this implementation assumes that this function is locally defined.
 
                 pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
-                call_direct(&mut ctx, function_index);
+                call_direct(&mut ctx, function_index, callee_ty.returns.len() as u32);
             }
             _ => {
                 trap(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -217,6 +217,9 @@ pub fn translate(
             Operator::GetLocal { local_index } => {
                 get_local_i32(&mut ctx, local_index);
             }
+            Operator::I32Const { value } => {
+                literal_i32(&mut ctx, value);
+            }
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
                 assert!(callee_ty.returns.len() == 0, "is not supported");

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -1,4 +1,5 @@
 use backend::*;
+use module::TranslationContext;
 use error::Error;
 use wasmparser::{FuncType, FunctionBody, Operator, Type};
 
@@ -88,6 +89,7 @@ impl ControlFrame {
 
 pub fn translate(
     session: &mut CodeGenSession,
+    translation_ctx: &TranslationContext,
     func_type: &FuncType,
     body: &FunctionBody,
 ) -> Result<(), Error> {

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -219,15 +219,12 @@ pub fn translate(
             }
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
-                assert!(callee_ty.params.len() == 0, "is not supported");
                 assert!(callee_ty.returns.len() == 0, "is not supported");
 
                 // TODO: ensure that this function is locally defined
                 // We would like to support imported functions at some point
 
-                // TODO: pop arguments and move them in appropriate positions.
-                // only 6 for now.
-
+                pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
                 call_direct(&mut ctx, function_index);
             }
             _ => {

--- a/src/module.rs
+++ b/src/module.rs
@@ -39,6 +39,8 @@ impl TranslationContext {
         let func_ty_idx = self.func_ty_indicies[func_idx as usize];
         &self.types[func_ty_idx as usize]
     }
+
+    // TODO: type of a global
 }
 
 /// Translate from a slice of bytes holding a wasm module.
@@ -155,8 +157,7 @@ pub fn translate(data: &[u8]) -> Result<TranslatedModule, Error> {
 
     if let SectionCode::Code = section.code {
         let code = section.get_code_section_reader()?;
-        output.translated_code_section =
-            Some(translate_sections::code(code, &ctx)?);
+        output.translated_code_section = Some(translate_sections::code(code, &ctx)?);
 
         reader.skip_custom_sections()?;
         if reader.eof() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -129,4 +129,18 @@ fn function_call() {
     assert_eq!(execute_wat(code, 2, 0), 2);
 }
 
+#[test]
+fn literals() {
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32)
+    (i32.const 228)
+  )
+)
+    "#;
+
+    assert_eq!(execute_wat(code, 0, 0), 228);
+}
+
+
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -111,16 +111,22 @@ fn function_call() {
     let code = r#"
 (module
   (func (param i32) (param i32) (result i32)
-    (call 1)
+    (call $assert_zero
+      (get_local 1)
+    )
     (get_local 0)
   )
 
-  (func
+  (func $assert_zero (param $v i32)
+    (local i32)
+    (if (get_local $v)
+      (unreachable)
+    )
   )
 )
     "#;
 
-    assert_eq!(execute_wat(code, 2, 3), 2);
+    assert_eq!(execute_wat(code, 2, 0), 2);
 }
 
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,5 +142,61 @@ fn literals() {
     assert_eq!(execute_wat(code, 0, 0), 228);
 }
 
+#[test]
+fn fib() {
+    let code = r#"
+(module
+  (func $fib (param $n i32) (param $_unused i32) (result i32)
+    (if (result i32)
+      (i32.eq
+        (i32.const 0)
+        (get_local $n)
+      )
+      (then
+        (i32.const 1)
+      )
+      (else
+        (if (result i32)
+          (i32.eq
+            (i32.const 1)
+            (get_local $n)
+          )
+          (then
+            (i32.const 1)
+          )
+          (else
+            (i32.add
+              ;; fib(n - 1)
+              (call $fib
+                (i32.add
+                  (get_local $n)
+                  (i32.const -1)
+                )
+                (i32.const 0)
+              )
+              ;; fib(n - 2)
+              (call $fib
+                (i32.add
+                  (get_local $n)
+                  (i32.const -2)
+                )
+                (i32.const 0)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+    "#;
+
+    // fac(x) = y <=> (x, y)
+    const FIB_SEQ: &[usize] = &[1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
+
+    for x in 0..10 {
+        assert_eq!(execute_wat(code, x, 0), FIB_SEQ[x]);
+    }
+}
 
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,11 +20,7 @@ fn empty() {
 
 #[test]
 fn adds() {
-    const CASES: &[(usize, usize, usize)] = &[
-        (5, 3, 8),
-        (0, 228, 228),
-        (usize::max_value(), 1, 0),
-    ];
+    const CASES: &[(usize, usize, usize)] = &[(5, 3, 8), (0, 228, 228), (usize::max_value(), 1, 0)];
 
     let code = r#"
 (module
@@ -103,6 +99,23 @@ fn if_without_result() {
     )
 
     (get_local 0)
+  )
+)
+    "#;
+
+    assert_eq!(execute_wat(code, 2, 3), 2);
+}
+
+#[test]
+fn function_call() {
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32)
+    (call 1)
+    (get_local 0)
+  )
+
+  (func
   )
 )
     "#;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,6 +14,11 @@ fn execute_wat(wat: &str, a: usize, b: usize) -> usize {
 }
 
 #[test]
+fn empty() {
+    let _ = translate_wat("(module (func))");
+}
+
+#[test]
 fn adds() {
     const CASES: &[(usize, usize, usize)] = &[
         (5, 3, 8),

--- a/src/translate_sections.rs
+++ b/src/translate_sections.rs
@@ -85,12 +85,12 @@ pub fn element(elements: ElementSectionReader) -> Result<(), Error> {
 /// Parses the Code section of the wasm module.
 pub fn code(
     code: CodeSectionReader,
-    translation_ctx: &TranslationContext
+    translation_ctx: &TranslationContext,
 ) -> Result<TranslatedCodeSection, Error> {
-    let mut session = CodeGenSession::new();
+    let func_count = code.get_count();
+    let mut session = CodeGenSession::new(func_count);
     for (idx, body) in code.into_iter().enumerate() {
-        let func_ty = translation_ctx.func_type(idx as u32);
-        function_body::translate(&mut session, translation_ctx, &func_ty, &body?)?;
+        function_body::translate(&mut session, translation_ctx, idx as u32, &body?)?;
     }
     Ok(session.into_translated_code_section()?)
 }

--- a/src/translate_sections.rs
+++ b/src/translate_sections.rs
@@ -1,6 +1,7 @@
 use backend::{CodeGenSession, TranslatedCodeSection};
 use error::Error;
 use function_body;
+use module::TranslationContext;
 #[allow(unused_imports)] // for now
 use wasmparser::{
     CodeSectionReader, Data, DataSectionReader, Element, ElementSectionReader, Export,
@@ -84,15 +85,12 @@ pub fn element(elements: ElementSectionReader) -> Result<(), Error> {
 /// Parses the Code section of the wasm module.
 pub fn code(
     code: CodeSectionReader,
-    types: &[FuncType],
-    func_ty_indicies: &[u32],
+    translation_ctx: &TranslationContext
 ) -> Result<TranslatedCodeSection, Error> {
     let mut session = CodeGenSession::new();
     for (idx, body) in code.into_iter().enumerate() {
-        let func_ty_idx = func_ty_indicies[idx];
-        let func_ty = &types[func_ty_idx as usize];
-
-        function_body::translate(&mut session, &func_ty, &body?)?;
+        let func_ty = translation_ctx.func_type(idx as u32);
+        function_body::translate(&mut session, translation_ctx, &func_ty, &body?)?;
     }
     Ok(session.into_translated_code_section()?)
 }


### PR DESCRIPTION
Second part of and, hopefully, closes #3 

For that, I started reading the type section and function section, to aggregate the information about function types. I decided to introduce a `TranslationContext` which holds all this data and, may be, will answer queries about global types, and other module specific information.

Then, I had to update the `CodeGenSession` to keep `DynamicLabel`s of functions. I did this in order to simplify the forward calling of functions. However, there seems to be no way of getting the `AssemblyOffset` from `DynamicLabel` so I had to keep them as well.

Along the way, I have implemented `i32.const` because... well, it turned out that it is very useful instruction : )

And of course, I implemented the `call` instruction. For now, I decided to implement it via two backend functions:

- `pass_outgoing_args`, which takes a function's `arity`.
- `call_direct`, which takes `function_index` and `return_arity`

I thought that this separation may be useful, because sometimes we find ourselves in a situation when we already have arguments in their places or we need some custom handling.

so basically, backend now knows and uses function starts.
