### PR TITLE
Generic arguments

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -22,7 +22,7 @@ fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 fn maybe_main() -> Result<(), String> {
     let data = read_to_end("test.wasm").map_err(|e| e.to_string())?;
     let translated = translate(&data).map_err(|e| e.to_string())?;
-    let result = translated.execute_func(0, 5, 3);
+    let result: u32 = unsafe { translated.execute_func(0, (5u32, 3u32)) };
     println!("f(5, 3) = {}", result);
 
     Ok(())


### PR DESCRIPTION
This builds on top of #7 and so cannot be merged before that. All my changes are rolled into https://github.com/CraneStation/lightbeam/pull/8/commits/86353cba5ed6c59725392097a59b2ab073ffe130 so you can just look at the patch for that commit instead of the combined changes (which include @pepyakin's function call work too).

This implements a generic argument trait which allows a user to call functions of any signature. In the future we probably want a safe way to call functions that checks the arguments at runtime. @pepyakin said that in his personal experiment https://github.com/pepyakin/fingerlift/ he implemented something like this.