### PR TITLE
Spill arguments to stack

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -22,7 +22,7 @@ fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 fn maybe_main() -> Result<(), String> {
     let data = read_to_end("test.wasm").map_err(|e| e.to_string())?;
     let translated = translate(&data).map_err(|e| e.to_string())?;
-    let result = translated.execute_func(0, 5, 3);
+    let result: u32 = unsafe { translated.execute_func(0, (5u32, 3u32)) };
     println!("f(5, 3) = {}", result);
 
     Ok(())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -89,13 +89,13 @@ enum ArgLocation {
     Stack(i32),
 }
 
+// TODO: This assumes only system-v calling convention.
+// In system-v calling convention the first 6 arguments are passed via registers.
+// All rest arguments are passed on the stack.
+const ARGS_IN_GPRS: &'static [GPR] = &[RDI, RSI, RDX, RCX, R8, R9];
+
 /// Get a location for an argument at the given position.
 fn abi_loc_for_arg(pos: u32) -> ArgLocation {
-    // TODO: This assumes only system-v calling convention.
-    // In system-v calling convention the first 6 arguments are passed via registers.
-    // All rest arguments are passed on the stack.
-    const ARGS_IN_GPRS: &'static [GPR] = &[RDI, RSI, RDX, RCX, R8, R9];
-
     if let Some(&reg) = ARGS_IN_GPRS.get(pos as usize) {
         ArgLocation::Reg(reg)
     } else {
@@ -342,7 +342,7 @@ pub fn prepare_return_value(ctx: &mut Context) {
     }
 }
 
-pub fn copy_incoming_arg(ctx: &mut Context, arg_pos: u32) {
+pub fn copy_incoming_arg(ctx: &mut Context, frame_size: u32, arg_pos: u32) {
     let loc = abi_loc_for_arg(arg_pos);
 
     // First, ensure the argument is in a register.
@@ -353,6 +353,7 @@ pub fn copy_incoming_arg(ctx: &mut Context, arg_pos: u32) {
                 ctx.regs.scratch_gprs.is_free(RAX),
                 "we assume that RAX can be used as a scratch register for now",
             );
+            let offset = offset + (frame_size * WORD_SIZE) as i32;
             dynasm!(ctx.asm
                 ; mov Rq(RAX), [rsp + offset]
             );
@@ -368,6 +369,7 @@ pub fn copy_incoming_arg(ctx: &mut Context, arg_pos: u32) {
 }
 
 pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
+    let mut stack_args = vec![];
     for arg_pos in (0..arity).rev() {
         ctx.sp_depth.free(1);
 
@@ -378,8 +380,21 @@ pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
                     ; pop Rq(gpr)
                 );
             }
-            _ => unimplemented!("don't know how to pass argument {} via {:?}", arg_pos, loc),
+            ArgLocation::Stack(_) => {
+                let gpr = ctx.regs.take_scratch_gpr();
+                dynasm!(ctx.asm
+                    ; pop Rq(gpr)
+                );
+                stack_args.push(gpr);
+            }
         }
+    }
+
+    for gpr in stack_args {
+        dynasm!(ctx.asm
+            ; push Rq(gpr)
+        );
+        ctx.regs.release_scratch_gpr(gpr);
     }
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -368,8 +368,9 @@ pub fn copy_incoming_arg(ctx: &mut Context, frame_size: u32, arg_pos: u32) {
     );
 }
 
-pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
-    let mut stack_args = vec![];
+#[must_use]
+fn pass_outgoing_args(ctx: &mut Context, arity: u32) -> i32 {
+    let mut stack_args = Vec::with_capacity((arity as usize).saturating_sub(ARGS_IN_GPRS.len()));
     for arg_pos in (0..arity).rev() {
         ctx.sp_depth.free(1);
 
@@ -390,21 +391,38 @@ pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
         }
     }
 
-    for gpr in stack_args {
+    let num_stack_args = stack_args.len() as i32;
+    dynasm!(ctx.asm
+        ; sub rsp, num_stack_args
+    );
+    for (stack_slot, gpr) in stack_args.into_iter().rev().enumerate() {
+        let offset = (stack_slot * WORD_SIZE as usize) as i32;
         dynasm!(ctx.asm
-            ; push Rq(gpr)
+            ; mov [rsp + offset], Rq(gpr)
         );
         ctx.regs.release_scratch_gpr(gpr);
     }
+
+    num_stack_args
 }
 
-pub fn call_direct(ctx: &mut Context, index: u32, return_arity: u32) {
+fn post_call_cleanup(ctx: &mut Context, num_stack_args: i32) {
+    dynasm!(ctx.asm
+        ; add rsp, num_stack_args
+    );
+}
+
+pub fn call_direct(ctx: &mut Context, index: u32, arg_arity: u32, return_arity: u32) {
     assert!(return_arity == 0 || return_arity == 1);
 
-    let label = &ctx.func_defs[index as usize].label;
+    let num_stack_args = pass_outgoing_args(ctx, arg_arity);
+
+    let label = &ctx.func_starts[index as usize].1;
     dynasm!(ctx.asm
         ; call =>*label
     );
+
+    post_call_cleanup(ctx, num_stack_args);
 
     if return_arity == 1 {
         dynasm!(ctx.asm

--- a/src/disassemble.rs
+++ b/src/disassemble.rs
@@ -20,7 +20,7 @@ pub fn disassemble(mem: &[u8]) -> Result<(), Error> {
         for b in i.bytes() {
             write!(&mut bytes_str, "{:02x} ", b).unwrap();
         }
-        write!(&mut line, "{:21}\t", bytes_str).unwrap();
+        write!(&mut line, "{:24}\t", bytes_str).unwrap();
 
         if let Some(s) = i.mnemonic() {
             write!(&mut line, "{}\t", s).unwrap();

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -226,8 +226,12 @@ pub fn translate(
                 // TODO: this implementation assumes that this function is locally defined.
                 // TODO: guarantee 16-byte alignment for calls as required by x86-64 ABI
 
-                pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
-                call_direct(&mut ctx, function_index, callee_ty.returns.len() as u32);
+                call_direct(
+                    &mut ctx,
+                    function_index,
+                    callee_ty.params.len() as u32,
+                    callee_ty.returns.len() as u32,
+                );
             }
             _ => {
                 trap(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -115,7 +115,7 @@ pub fn translate(
     prologue(&mut ctx, framesize);
 
     for arg_pos in 0..arg_count {
-        copy_incoming_arg(&mut ctx, arg_pos);
+        copy_incoming_arg(&mut ctx, framesize, arg_pos);
     }
 
     let mut control_frames = Vec::new();


### PR DESCRIPTION
This PR builds on #8 and should not be merged before that. Relevant changes are https://github.com/CraneStation/lightbeam/pull/9/commits/189996accd3b83e42bb12df408c687e86df50a3b and onwards.

CC #3 

This allows calling functions with more than 6 arguments. It also fixes _receiving_ more than 6 arguments, which was broken until now (since the frame size was subtracted from `rsp` before reading the arguments). I just add `frame_size` to the offset (instead of, for example, reading arguments before subtracting from `rsp`) since that's what LLVM appears to do.