### PR TITLE
Implement simple binary operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ capstone = "0.5.0"
 failure = "0.1.3"
 failure_derive = "0.1.3"
 wabt = "0.7"
+lazy_static = "1.2"
+quickcheck = "0.7"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -22,7 +22,7 @@ fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 fn maybe_main() -> Result<(), String> {
     let data = read_to_end("test.wasm").map_err(|e| e.to_string())?;
     let translated = translate(&data).map_err(|e| e.to_string())?;
-    let result = translated.execute_func(0, 5, 3);
+    let result: u32 = unsafe { translated.execute_func(0, (5u32, 3u32)) };
     println!("f(5, 3) = {}", result);
 
     Ok(())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -182,6 +182,7 @@ impl CodeGenSession {
     }
 }
 
+#[derive(Debug)]
 pub struct TranslatedCodeSection {
     exec_buf: ExecutableBuffer,
     func_defs: Vec<AssemblyOffset>,
@@ -191,6 +192,10 @@ impl TranslatedCodeSection {
     pub fn func_start(&self, idx: usize) -> *const u8 {
         let offset = self.func_defs[idx];
         self.exec_buf.ptr(offset)
+    }
+
+    pub fn disassemble(&self) {
+        ::disassemble::disassemble(&*self.exec_buf).unwrap();
     }
 }
 
@@ -260,14 +265,64 @@ fn pop_i32(ctx: &mut Context) -> GPR {
     gpr
 }
 
-pub fn add_i32(ctx: &mut Context) {
+pub fn i32_add(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
     let op1 = pop_i32(ctx);
     dynasm!(ctx.asm
-        ; add Rd(op0), Rd(op1)
+        ; add Rd(op1), Rd(op0)
     );
-    push_i32(ctx, op0);
-    ctx.regs.release_scratch_gpr(op1);
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_sub(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; sub Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_and(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; and Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_or(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; or Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_xor(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; xor Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_mul(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; imul Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
 }
 
 fn sp_relative_offset(ctx: &mut Context, slot_idx: u32) -> i32 {
@@ -400,6 +455,7 @@ pub fn call_direct(ctx: &mut Context, index: u32, return_arity: u32) {
 }
 
 pub fn prologue(ctx: &mut Context, stack_slots: u32) {
+    let stack_slots = stack_slots;
     // Align stack slots to the nearest even number. This is required
     // by x86-64 ABI.
     let aligned_stack_slots = (stack_slots + 1) & !1;

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -208,18 +208,15 @@ pub fn translate(
                     }
                 }
             }
-            Operator::I32Eq => {
-                relop_eq_i32(&mut ctx);
-            }
-            Operator::I32Add => {
-                add_i32(&mut ctx);
-            }
-            Operator::GetLocal { local_index } => {
-                get_local_i32(&mut ctx, local_index);
-            }
-            Operator::I32Const { value } => {
-                literal_i32(&mut ctx, value);
-            }
+            Operator::I32Eq => relop_eq_i32(&mut ctx),
+            Operator::I32Add => i32_add(&mut ctx),
+            Operator::I32Sub => i32_sub(&mut ctx),
+            Operator::I32And => i32_and(&mut ctx),
+            Operator::I32Or => i32_or(&mut ctx),
+            Operator::I32Xor => i32_xor(&mut ctx),
+            Operator::I32Mul => i32_mul(&mut ctx),
+            Operator::GetLocal { local_index } => get_local_i32(&mut ctx, local_index),
+            Operator::I32Const { value } => literal_i32(&mut ctx, value),
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@ extern crate wasmparser;
 #[macro_use]
 extern crate failure_derive;
 extern crate dynasmrt;
-
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate quickcheck;
 extern crate wabt;
 
 mod backend;

--- a/src/module.rs
+++ b/src/module.rs
@@ -52,6 +52,13 @@ impl TranslatedModule {
 
         args.call(start_buf)
     }
+
+    pub fn disassemble(&self) {
+        self.translated_code_section
+            .as_ref()
+            .expect("no code section")
+            .disassemble();
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
This PR builds on #8 and should not be merged before that. All the changes are rolled into https://github.com/CraneStation/lightbeam/pull/10/commits/df25fee20fab0b8c4bad368f3c5e8604eb0bfc91.

CC #4 

This implements the simplest operations (add/sub/and/or/xor/mul) that map directly onto x86 instructions. It also adds quickcheck to make testing these (and probably other things too, although I haven't tried yet) a lot easier.