### PR TITLE
Simple register allocation for `push`/`pop` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ capstone = "0.5.0"
 failure = "0.1.3"
 failure_derive = "0.1.3"
 wabt = "0.7"
+lazy_static = "1.2"
+quickcheck = "0.7"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -22,7 +22,7 @@ fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 fn maybe_main() -> Result<(), String> {
     let data = read_to_end("test.wasm").map_err(|e| e.to_string())?;
     let translated = translate(&data).map_err(|e| e.to_string())?;
-    let result = translated.execute_func(0, 5, 3);
+    let result: u32 = unsafe { translated.execute_func(0, (5u32, 3u32)) };
     println!("f(5, 3) = {}", result);
 
     Ok(())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -574,12 +574,9 @@ pub fn prologue(ctx: &mut Context, stack_slots: u32) {
 }
 
 pub fn epilogue(ctx: &mut Context) {
-    // TODO: This doesn't work with stack alignment.
-    // assert_eq!(
-    //     ctx.sp_depth,
-    //     StackDepth(0),
-    //     "imbalanced pushes and pops detected"
-    // );
+    // We don't need to clean up the stack - `rsp` is restored and
+    // the calling function has its own register stack and will
+    // stomp on the registers from our stack if necessary.
     dynasm!(ctx.asm
         ; mov rsp, rbp
         ; pop rbp

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -261,13 +261,21 @@ pub fn get_local_i32(ctx: &mut Context, local_idx: u32) {
     push_i32(ctx, gpr);
 }
 
-pub fn store_i32(ctx: &mut Context, local_idx: u32) {
+pub fn set_local_i32(ctx: &mut Context, local_idx: u32) {
     let gpr = pop_i32(ctx);
     let offset = sp_relative_offset(ctx, local_idx);
     dynasm!(ctx.asm
         ; mov [rsp + offset], Rq(gpr)
     );
     ctx.regs.release_scratch_gpr(gpr);
+}
+
+pub fn literal_i32(ctx: &mut Context, imm: i32) {
+    let gpr = ctx.regs.take_scratch_gpr();
+    dynasm!(ctx.asm
+        ; mov Rd(gpr), imm
+    );
+    push_i32(ctx, gpr);
 }
 
 pub fn relop_eq_i32(ctx: &mut Context) {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -361,11 +361,20 @@ pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
     }
 }
 
-pub fn call_direct(ctx: &mut Context, index: u32) {
+pub fn call_direct(ctx: &mut Context, index: u32, return_arity: u32) {
+    assert!(return_arity == 0 || return_arity == 1);
+
     let label = &ctx.func_starts[index as usize].1;
     dynasm!(ctx.asm
         ; call =>*label
     );
+
+    if return_arity == 1 {
+        dynasm!(ctx.asm
+            ; push rax
+        );
+        ctx.sp_depth.reserve(1);
+    }
 }
 
 pub fn prologue(ctx: &mut Context, stack_slots: u32) {

--- a/src/disassemble.rs
+++ b/src/disassemble.rs
@@ -20,7 +20,7 @@ pub fn disassemble(mem: &[u8]) -> Result<(), Error> {
         for b in i.bytes() {
             write!(&mut bytes_str, "{:02x} ", b).unwrap();
         }
-        write!(&mut line, "{:21}\t", bytes_str).unwrap();
+        write!(&mut line, "{:24}\t", bytes_str).unwrap();
 
         if let Some(s) = i.mnemonic() {
             write!(&mut line, "{}\t", s).unwrap();

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -208,18 +208,15 @@ pub fn translate(
                     }
                 }
             }
-            Operator::I32Eq => {
-                relop_eq_i32(&mut ctx);
-            }
-            Operator::I32Add => {
-                add_i32(&mut ctx);
-            }
-            Operator::GetLocal { local_index } => {
-                get_local_i32(&mut ctx, local_index);
-            }
-            Operator::I32Const { value } => {
-                literal_i32(&mut ctx, value);
-            }
+            Operator::I32Eq => relop_eq_i32(&mut ctx),
+            Operator::I32Add => i32_add(&mut ctx),
+            Operator::I32Sub => i32_sub(&mut ctx),
+            Operator::I32And => i32_and(&mut ctx),
+            Operator::I32Or => i32_or(&mut ctx),
+            Operator::I32Xor => i32_xor(&mut ctx),
+            Operator::I32Mul => i32_mul(&mut ctx),
+            Operator::GetLocal { local_index } => get_local_i32(&mut ctx, local_index),
+            Operator::I32Const { value } => literal_i32(&mut ctx, value),
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
 

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -115,7 +115,7 @@ pub fn translate(
     prologue(&mut ctx, framesize);
 
     for arg_pos in 0..arg_count {
-        copy_incoming_arg(&mut ctx, arg_pos);
+        copy_incoming_arg(&mut ctx, framesize, arg_pos);
     }
 
     let mut control_frames = Vec::new();

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -222,13 +222,11 @@ pub fn translate(
             }
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
-                assert!(callee_ty.returns.len() == 0, "is not supported");
 
-                // TODO: ensure that this function is locally defined
-                // We would like to support imported functions at some point
+                // TODO: this implementation assumes that this function is locally defined.
 
                 pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
-                call_direct(&mut ctx, function_index);
+                call_direct(&mut ctx, function_index, callee_ty.returns.len() as u32);
             }
             _ => {
                 trap(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -225,8 +225,12 @@ pub fn translate(
 
                 // TODO: this implementation assumes that this function is locally defined.
 
-                pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
-                call_direct(&mut ctx, function_index, callee_ty.returns.len() as u32);
+                call_direct(
+                    &mut ctx,
+                    function_index,
+                    callee_ty.params.len() as u32,
+                    callee_ty.returns.len() as u32,
+                );
             }
             _ => {
                 trap(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -217,6 +217,9 @@ pub fn translate(
             Operator::GetLocal { local_index } => {
                 get_local_i32(&mut ctx, local_index);
             }
+            Operator::I32Const { value } => {
+                literal_i32(&mut ctx, value);
+            }
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
                 assert!(callee_ty.returns.len() == 0, "is not supported");

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -1,4 +1,5 @@
 use backend::*;
+use module::TranslationContext;
 use error::Error;
 use wasmparser::{FuncType, FunctionBody, Operator, Type};
 
@@ -88,6 +89,7 @@ impl ControlFrame {
 
 pub fn translate(
     session: &mut CodeGenSession,
+    translation_ctx: &TranslationContext,
     func_type: &FuncType,
     body: &FunctionBody,
 ) -> Result<(), Error> {

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -219,15 +219,12 @@ pub fn translate(
             }
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
-                assert!(callee_ty.params.len() == 0, "is not supported");
                 assert!(callee_ty.returns.len() == 0, "is not supported");
 
                 // TODO: ensure that this function is locally defined
                 // We would like to support imported functions at some point
 
-                // TODO: pop arguments and move them in appropriate positions.
-                // only 6 for now.
-
+                pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
                 call_direct(&mut ctx, function_index);
             }
             _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
-#![feature(plugin)]
+#![feature(plugin, test)]
 #![plugin(dynasm)]
+
+extern crate test;
 
 extern crate capstone;
 extern crate failure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,10 @@ extern crate wasmparser;
 #[macro_use]
 extern crate failure_derive;
 extern crate dynasmrt;
+#[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
+#[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
 extern crate wabt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@ extern crate wasmparser;
 #[macro_use]
 extern crate failure_derive;
 extern crate dynasmrt;
-
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate quickcheck;
 extern crate wabt;
 
 mod backend;

--- a/src/module.rs
+++ b/src/module.rs
@@ -52,6 +52,13 @@ impl TranslatedModule {
 
         args.call(start_buf)
     }
+
+    pub fn disassemble(&self) {
+        self.translated_code_section
+            .as_ref()
+            .expect("no code section")
+            .disassemble();
+    }
 }
 
 #[derive(Default)]

--- a/src/module.rs
+++ b/src/module.rs
@@ -39,6 +39,8 @@ impl TranslationContext {
         let func_ty_idx = self.func_ty_indicies[func_idx as usize];
         &self.types[func_ty_idx as usize]
     }
+
+    // TODO: type of a global
 }
 
 /// Translate from a slice of bytes holding a wasm module.
@@ -155,8 +157,7 @@ pub fn translate(data: &[u8]) -> Result<TranslatedModule, Error> {
 
     if let SectionCode::Code = section.code {
         let code = section.get_code_section_reader()?;
-        output.translated_code_section =
-            Some(translate_sections::code(code, &ctx)?);
+        output.translated_code_section = Some(translate_sections::code(code, &ctx)?);
 
         reader.skip_custom_sections()?;
         if reader.eof() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -270,9 +270,7 @@ fn literals() {
     assert_eq!(execute_wat(code, 0, 0), 228);
 }
 
-#[test]
-fn fib() {
-    let code = r#"
+const FIBONACCI: &str = r#"
 (module
   (func $fib (param $n i32) (param $_unused i32) (result i32)
     (if (result i32)
@@ -319,19 +317,34 @@ fn fib() {
 )
     "#;
 
+#[test]
+fn fib() {
     // fac(x) = y <=> (x, y)
     const FIB_SEQ: &[u32] = &[1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
 
-    let translated = translate_wat(code);
+    let translated = translate_wat(FIBONACCI);
 
     for x in 0..10 {
         unsafe {
             assert_eq!(
-                translated.execute_func::<_, u32>(0, (x, 0)),
+                translated.execute_func::<_, u32>(0, (x, 0u32)),
                 FIB_SEQ[x as usize]
             );
         }
     }
 }
 
-// TODO: Add a test that checks argument passing via the stack.
+#[bench]
+fn bench_compile(b: &mut test::Bencher) {
+    let wasm = wabt::wat2wasm(FIBONACCI).unwrap();
+
+    b.iter(|| test::black_box(translate(&wasm).unwrap()));
+}
+
+#[bench]
+fn bench_run(b: &mut test::Bencher) {
+    let wasm = wabt::wat2wasm(FIBONACCI).unwrap();
+    let module = translate(&wasm).unwrap();
+
+    b.iter(|| unsafe { module.execute_func::<_, u32>(0, (20, 0u32)) });
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -272,7 +272,7 @@ fn literals() {
 
 const FIBONACCI: &str = r#"
 (module
-  (func $fib (param $n i32) (param $_unused i32) (result i32)
+  (func $fib (param $n i32) (result i32)
     (if (result i32)
       (i32.eq
         (i32.const 0)
@@ -298,7 +298,6 @@ const FIBONACCI: &str = r#"
                   (get_local $n)
                   (i32.const -1)
                 )
-                (i32.const 0)
               )
               ;; fib(n - 2)
               (call $fib
@@ -306,7 +305,6 @@ const FIBONACCI: &str = r#"
                   (get_local $n)
                   (i32.const -2)
                 )
-                (i32.const 0)
               )
             )
           )
@@ -327,7 +325,7 @@ fn fib() {
     for x in 0..10 {
         unsafe {
             assert_eq!(
-                translated.execute_func::<_, u32>(0, (x, 0u32)),
+                translated.execute_func::<_, u32>(0, (x,)),
                 FIB_SEQ[x as usize]
             );
         }
@@ -346,5 +344,5 @@ fn bench_run(b: &mut test::Bencher) {
     let wasm = wabt::wat2wasm(FIBONACCI).unwrap();
     let module = translate(&wasm).unwrap();
 
-    b.iter(|| unsafe { module.execute_func::<_, u32>(0, (20, 0u32)) });
+    b.iter(|| unsafe { module.execute_func::<_, u32>(0, (20,)) });
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -322,8 +322,15 @@ fn fib() {
     // fac(x) = y <=> (x, y)
     const FIB_SEQ: &[u32] = &[1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
 
+    let translated = translate_wat(code);
+
     for x in 0..10 {
-        assert_eq!(execute_wat(code, x, 0), FIB_SEQ[x as usize]);
+        unsafe {
+            assert_eq!(
+                translated.execute_func::<_, u32>(0, (x, 0)),
+                FIB_SEQ[x as usize]
+            );
+        }
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -129,4 +129,18 @@ fn function_call() {
     assert_eq!(execute_wat(code, 2, 0), 2);
 }
 
+#[test]
+fn literals() {
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32)
+    (i32.const 228)
+  )
+)
+    "#;
+
+    assert_eq!(execute_wat(code, 0, 0), 228);
+}
+
+
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -111,16 +111,22 @@ fn function_call() {
     let code = r#"
 (module
   (func (param i32) (param i32) (result i32)
-    (call 1)
+    (call $assert_zero
+      (get_local 1)
+    )
     (get_local 0)
   )
 
-  (func
+  (func $assert_zero (param $v i32)
+    (local i32)
+    (if (get_local $v)
+      (unreachable)
+    )
   )
 )
     "#;
 
-    assert_eq!(execute_wat(code, 2, 3), 2);
+    assert_eq!(execute_wat(code, 2, 0), 2);
 }
 
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -142,5 +142,61 @@ fn literals() {
     assert_eq!(execute_wat(code, 0, 0), 228);
 }
 
+#[test]
+fn fib() {
+    let code = r#"
+(module
+  (func $fib (param $n i32) (param $_unused i32) (result i32)
+    (if (result i32)
+      (i32.eq
+        (i32.const 0)
+        (get_local $n)
+      )
+      (then
+        (i32.const 1)
+      )
+      (else
+        (if (result i32)
+          (i32.eq
+            (i32.const 1)
+            (get_local $n)
+          )
+          (then
+            (i32.const 1)
+          )
+          (else
+            (i32.add
+              ;; fib(n - 1)
+              (call $fib
+                (i32.add
+                  (get_local $n)
+                  (i32.const -1)
+                )
+                (i32.const 0)
+              )
+              ;; fib(n - 2)
+              (call $fib
+                (i32.add
+                  (get_local $n)
+                  (i32.const -2)
+                )
+                (i32.const 0)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+    "#;
+
+    // fac(x) = y <=> (x, y)
+    const FIB_SEQ: &[usize] = &[1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
+
+    for x in 0..10 {
+        assert_eq!(execute_wat(code, x, 0), FIB_SEQ[x]);
+    }
+}
 
 // TODO: Add a test that checks argument passing via the stack.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,11 +20,7 @@ fn empty() {
 
 #[test]
 fn adds() {
-    const CASES: &[(usize, usize, usize)] = &[
-        (5, 3, 8),
-        (0, 228, 228),
-        (usize::max_value(), 1, 0),
-    ];
+    const CASES: &[(usize, usize, usize)] = &[(5, 3, 8), (0, 228, 228), (usize::max_value(), 1, 0)];
 
     let code = r#"
 (module
@@ -103,6 +99,23 @@ fn if_without_result() {
     )
 
     (get_local 0)
+  )
+)
+    "#;
+
+    assert_eq!(execute_wat(code, 2, 3), 2);
+}
+
+#[test]
+fn function_call() {
+    let code = r#"
+(module
+  (func (param i32) (param i32) (result i32)
+    (call 1)
+    (get_local 0)
+  )
+
+  (func
   )
 )
     "#;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,6 +14,11 @@ fn execute_wat(wat: &str, a: usize, b: usize) -> usize {
 }
 
 #[test]
+fn empty() {
+    let _ = translate_wat("(module (func))");
+}
+
+#[test]
 fn adds() {
     const CASES: &[(usize, usize, usize)] = &[
         (5, 3, 8),

--- a/src/translate_sections.rs
+++ b/src/translate_sections.rs
@@ -85,12 +85,12 @@ pub fn element(elements: ElementSectionReader) -> Result<(), Error> {
 /// Parses the Code section of the wasm module.
 pub fn code(
     code: CodeSectionReader,
-    translation_ctx: &TranslationContext
+    translation_ctx: &TranslationContext,
 ) -> Result<TranslatedCodeSection, Error> {
-    let mut session = CodeGenSession::new();
+    let func_count = code.get_count();
+    let mut session = CodeGenSession::new(func_count);
     for (idx, body) in code.into_iter().enumerate() {
-        let func_ty = translation_ctx.func_type(idx as u32);
-        function_body::translate(&mut session, translation_ctx, &func_ty, &body?)?;
+        function_body::translate(&mut session, translation_ctx, idx as u32, &body?)?;
     }
     Ok(session.into_translated_code_section()?)
 }

--- a/src/translate_sections.rs
+++ b/src/translate_sections.rs
@@ -1,6 +1,7 @@
 use backend::{CodeGenSession, TranslatedCodeSection};
 use error::Error;
 use function_body;
+use module::TranslationContext;
 #[allow(unused_imports)] // for now
 use wasmparser::{
     CodeSectionReader, Data, DataSectionReader, Element, ElementSectionReader, Export,
@@ -84,15 +85,12 @@ pub fn element(elements: ElementSectionReader) -> Result<(), Error> {
 /// Parses the Code section of the wasm module.
 pub fn code(
     code: CodeSectionReader,
-    types: &[FuncType],
-    func_ty_indicies: &[u32],
+    translation_ctx: &TranslationContext
 ) -> Result<TranslatedCodeSection, Error> {
     let mut session = CodeGenSession::new();
     for (idx, body) in code.into_iter().enumerate() {
-        let func_ty_idx = func_ty_indicies[idx];
-        let func_ty = &types[func_ty_idx as usize];
-
-        function_body::translate(&mut session, &func_ty, &body?)?;
+        let func_ty = translation_ctx.func_type(idx as u32);
+        function_body::translate(&mut session, translation_ctx, &func_ty, &body?)?;
     }
     Ok(session.into_translated_code_section()?)
 }


### PR DESCRIPTION
This PR builds on top of #10 and #9, although strictly speaking it doesn't need to build on #10 (it only does so so we have more test cases). The relevant changes are https://github.com/CraneStation/lightbeam/pull/11/commits/698ce5ad949c7957a047c6dd5667bea7f73ab3dc and onwards.

This implements simple register allocation for `push_i32` and `pop_i32`. This prevents a lot of the shuffling around of values that we see. This is probably wildly unsound in some obscure, inscrutable way, so don't be afraid to bust my balls in the code review.