### PR TITLE
Register stack v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ capstone = "0.5.0"
 failure = "0.1.3"
 failure_derive = "0.1.3"
 wabt = "0.7"
+lazy_static = "1.2"
+quickcheck = "0.7"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["webassembly", "wasm", "compile", "compiler", "jit"]
 publish = false
 
 [dependencies]
+arrayvec = "0.4"
 dynasm = "0.2.3"
 dynasmrt = "0.2.3"
 wasmparser = "0.21.6"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -22,7 +22,7 @@ fn read_to_end<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 fn maybe_main() -> Result<(), String> {
     let data = read_to_end("test.wasm").map_err(|e| e.to_string())?;
     let translated = translate(&data).map_err(|e| e.to_string())?;
-    let result = translated.execute_func(0, 5, 3);
+    let result: u32 = unsafe { translated.execute_func(0, (5u32, 3u32)) };
     println!("f(5, 3) = {}", result);
 
     Ok(())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -89,13 +89,13 @@ enum ArgLocation {
     Stack(i32),
 }
 
+// TODO: This assumes only system-v calling convention.
+// In system-v calling convention the first 6 arguments are passed via registers.
+// All rest arguments are passed on the stack.
+const ARGS_IN_GPRS: &'static [GPR] = &[RDI, RSI, RDX, RCX, R8, R9];
+
 /// Get a location for an argument at the given position.
 fn abi_loc_for_arg(pos: u32) -> ArgLocation {
-    // TODO: This assumes only system-v calling convention.
-    // In system-v calling convention the first 6 arguments are passed via registers.
-    // All rest arguments are passed on the stack.
-    const ARGS_IN_GPRS: &'static [GPR] = &[RDI, RSI, RDX, RCX, R8, R9];
-
     if let Some(&reg) = ARGS_IN_GPRS.get(pos as usize) {
         ArgLocation::Reg(reg)
     } else {
@@ -342,7 +342,7 @@ pub fn prepare_return_value(ctx: &mut Context) {
     }
 }
 
-pub fn copy_incoming_arg(ctx: &mut Context, arg_pos: u32) {
+pub fn copy_incoming_arg(ctx: &mut Context, frame_size: u32, arg_pos: u32) {
     let loc = abi_loc_for_arg(arg_pos);
 
     // First, ensure the argument is in a register.
@@ -353,6 +353,7 @@ pub fn copy_incoming_arg(ctx: &mut Context, arg_pos: u32) {
                 ctx.regs.scratch_gprs.is_free(RAX),
                 "we assume that RAX can be used as a scratch register for now",
             );
+            let offset = offset + (frame_size * WORD_SIZE) as i32;
             dynasm!(ctx.asm
                 ; mov Rq(RAX), [rsp + offset]
             );
@@ -368,6 +369,7 @@ pub fn copy_incoming_arg(ctx: &mut Context, arg_pos: u32) {
 }
 
 pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
+    let mut stack_args = vec![];
     for arg_pos in (0..arity).rev() {
         ctx.sp_depth.free(1);
 
@@ -378,8 +380,21 @@ pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
                     ; pop Rq(gpr)
                 );
             }
-            _ => unimplemented!("don't know how to pass argument {} via {:?}", arg_pos, loc),
+            ArgLocation::Stack(_) => {
+                let gpr = ctx.regs.take_scratch_gpr();
+                dynasm!(ctx.asm
+                    ; pop Rq(gpr)
+                );
+                stack_args.push(gpr);
+            }
         }
+    }
+
+    for gpr in stack_args {
+        dynasm!(ctx.asm
+            ; push Rq(gpr)
+        );
+        ctx.regs.release_scratch_gpr(gpr);
     }
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,6 +10,7 @@ const WORD_SIZE: u32 = 8;
 
 type GPR = u8;
 
+#[derive(Copy, Clone)]
 struct GPRs {
     bits: u16,
 }
@@ -36,13 +37,19 @@ const R12: u8 = 12;
 const R13: u8 = 13;
 const R14: u8 = 14;
 const R15: u8 = 15;
+const NUM_GPRS: u8 = 16;
 
 impl GPRs {
     fn take(&mut self) -> GPR {
         let lz = self.bits.trailing_zeros();
-        assert!(lz < 32, "ran out of free GPRs");
-        self.bits &= !(1 << lz);
-        lz as GPR
+        assert!(lz < 16, "ran out of free GPRs");
+        let gpr = lz as GPR;
+        self.mark_used(gpr);
+        gpr
+    }
+
+    fn mark_used(&mut self, gpr: GPR) {
+        self.bits &= !(1 << gpr as u16);
     }
 
     fn release(&mut self, gpr: GPR) {
@@ -50,62 +57,80 @@ impl GPRs {
         self.bits |= 1 << gpr;
     }
 
+    fn free_count(&self) -> u32 {
+        self.bits.count_ones()
+    }
+
     fn is_free(&self, gpr: GPR) -> bool {
         (self.bits & (1 << gpr)) != 0
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct Registers {
-    scratch_gprs: GPRs,
+    scratch: GPRs,
+}
+
+impl Default for Registers {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Registers {
     pub fn new() -> Self {
         let mut result = Self {
-            scratch_gprs: GPRs::new(),
+            scratch: GPRs::new(),
         };
         // Give ourselves a few scratch registers to work with, for now.
-        result.release_scratch_gpr(RAX);
-        result.release_scratch_gpr(RCX);
-        result.release_scratch_gpr(RDX);
+        for &scratch in SCRATCH_REGS {
+            result.release_scratch_gpr(scratch);
+        }
+
         result
     }
 
+    // TODO: Add function that takes a scratch register if possible
+    //       but otherwise gives a fresh stack location.
     pub fn take_scratch_gpr(&mut self) -> GPR {
-        self.scratch_gprs.take()
+        self.scratch.take()
     }
 
     pub fn release_scratch_gpr(&mut self, gpr: GPR) {
-        self.scratch_gprs.release(gpr);
+        self.scratch.release(gpr);
+    }
+
+    pub fn is_free(&self, gpr: GPR) -> bool {
+        self.scratch.is_free(gpr)
+    }
+
+    pub fn free_scratch(&self) -> u32 {
+        self.scratch.free_count()
     }
 }
 
-/// Describes location of a argument.
-#[derive(Debug)]
-enum ArgLocation {
-    /// Argument is passed via some register.
+/// Describes location of a value.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ValueLocation {
+    /// Value exists in a register.
     Reg(GPR),
-    /// Value is passed thru the stack.
+    /// Value exists on the stack. This is an offset relative to the
+    /// first local, and so will have to be adjusted with `adjusted_offset`
+    /// before reading (as RSP may have been changed by `push`/`pop`).
     Stack(i32),
 }
 
 // TODO: This assumes only system-v calling convention.
 // In system-v calling convention the first 6 arguments are passed via registers.
 // All rest arguments are passed on the stack.
-const ARGS_IN_GPRS: &'static [GPR] = &[RDI, RSI, RDX, RCX, R8, R9];
-
-/// Get a location for an argument at the given position.
-fn abi_loc_for_arg(pos: u32) -> ArgLocation {
-    if let Some(&reg) = ARGS_IN_GPRS.get(pos as usize) {
-        ArgLocation::Reg(reg)
-    } else {
-        let stack_pos = pos - ARGS_IN_GPRS.len() as u32;
-        // +2 is because the first argument is located right after the saved frame pointer slot
-        // and the incoming return address.
-        let stack_offset = ((stack_pos + 2) * WORD_SIZE) as i32;
-        ArgLocation::Stack(stack_offset)
-    }
-}
+const ARGS_IN_GPRS: &[GPR] = &[RDI, RSI, RDX, RCX, R8, R9];
+// RAX is reserved for return values. In the future we want a system to allow
+// use of specific registers by saving/restoring them. This would allow using
+// RAX as a scratch register when we're not calling a function, and would also
+// allow us to call instructions that require specific registers.
+//
+// List of scratch registers taken from https://wiki.osdev.org/System_V_ABI
+const SCRATCH_REGS: &[GPR] = &[R10, R11];
 
 /// Records data about the function.
 struct FuncDef {
@@ -159,9 +184,9 @@ impl CodeGenSession {
 
         Context {
             asm: &mut self.assembler,
-            func_defs: &self.func_defs,
-            regs: Registers::new(),
-            sp_depth: StackDepth(0),
+            func_starts: &self.func_starts,
+            block_state: Default::default(),
+            locals: Default::default(),
         }
     }
 
@@ -199,13 +224,77 @@ impl TranslatedCodeSection {
     }
 }
 
+// TODO: Immediates? We could implement on-the-fly const folding
+#[derive(Copy, Clone)]
+enum Value {
+    Local(u32),
+    Temp(GPR),
+}
+
+impl Value {
+    fn location(&self, locals: &Locals) -> ValueLocation {
+        match *self {
+            Value::Local(loc) => local_location(locals, loc),
+            Value::Temp(reg) => ValueLocation::Reg(reg),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum StackValue {
+    Local(u32),
+    Temp(GPR),
+    Pop,
+}
+
+impl StackValue {
+    fn location(&self, locals: &Locals) -> Option<ValueLocation> {
+        match *self {
+            StackValue::Local(loc) => Some(local_location(locals, loc)),
+            StackValue::Temp(reg) => Some(ValueLocation::Reg(reg)),
+            StackValue::Pop => None,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Locals {
+    // TODO: Use `ArrayVec` since we have a hard maximum (the number of registers)
+    locs: Vec<ValueLocation>,
+}
+
+#[derive(Default, Clone)]
+pub struct BlockState {
+    stack: Stack,
+    depth: StackDepth,
+    regs: Registers,
+}
+
+fn adjusted_offset(ctx: &mut Context, offset: i32) -> i32 {
+    (ctx.block_state.depth.0 * WORD_SIZE) as i32 + offset
+}
+
+fn local_location(locals: &Locals, index: u32) -> ValueLocation {
+    locals
+        .locs
+        .get(index as usize)
+        .cloned()
+        .unwrap_or(ValueLocation::Stack(
+            (index.saturating_sub(ARGS_IN_GPRS.len() as u32) * WORD_SIZE) as _,
+        ))
+}
+
+type Stack = Vec<StackValue>;
+
 pub struct Context<'a> {
     asm: &'a mut Assembler,
-    func_defs: &'a Vec<FuncDef>,
-    regs: Registers,
+    func_starts: &'a Vec<(Option<AssemblyOffset>, DynamicLabel)>,
     /// Each push and pop on the value stack increments or decrements this value by 1 respectively.
-    sp_depth: StackDepth,
+    block_state: BlockState,
+    locals: Locals,
 }
+
+impl<'a> Context<'a> {}
 
 /// Label in code.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -225,7 +314,7 @@ pub fn define_label(ctx: &mut Context, label: Label) {
 }
 
 /// Offset from starting value of SP counted in words.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StackDepth(u32);
 
 impl StackDepth {
@@ -238,146 +327,298 @@ impl StackDepth {
     }
 }
 
-pub fn current_stack_depth(ctx: &Context) -> StackDepth {
-    ctx.sp_depth
+pub fn current_block_state(ctx: &Context) -> BlockState {
+    ctx.block_state.clone()
 }
 
-pub fn restore_stack_depth(ctx: &mut Context, stack_depth: StackDepth) {
-    ctx.sp_depth = stack_depth;
+pub fn restore_block_state(ctx: &mut Context, block_state: BlockState) {
+    ctx.block_state = block_state;
 }
 
-fn push_i32(ctx: &mut Context, gpr: GPR) {
-    // For now, do an actual push (and pop below). In the future, we could
-    // do on-the-fly register allocation here.
-    ctx.sp_depth.reserve(1);
-    dynasm!(ctx.asm
-        ; push Rq(gpr)
-    );
-    ctx.regs.release_scratch_gpr(gpr);
+pub fn push_return_value(ctx: &mut Context) {
+    ctx.block_state.stack.push(StackValue::Temp(RAX));
 }
 
-fn pop_i32(ctx: &mut Context) -> GPR {
-    ctx.sp_depth.free(1);
-    let gpr = ctx.regs.take_scratch_gpr();
-    dynasm!(ctx.asm
-        ; pop Rq(gpr)
-    );
-    gpr
+fn push_i32(ctx: &mut Context, value: Value) {
+    let stack_loc = match value {
+        Value::Local(loc) => StackValue::Local(loc),
+        Value::Temp(gpr) => {
+            if ctx.block_state.regs.free_scratch() >= 1 {
+                StackValue::Temp(gpr)
+            } else {
+                ctx.block_state.depth.reserve(1);
+                dynasm!(ctx.asm
+                    ; push Rq(gpr)
+                );
+                ctx.block_state.regs.release_scratch_gpr(gpr);
+                StackValue::Pop
+            }
+        }
+    };
+
+    ctx.block_state.stack.push(stack_loc);
 }
 
+fn pop_i32(ctx: &mut Context) -> Value {
+    match ctx.block_state.stack.pop().expect("Stack is empty") {
+        StackValue::Local(loc) => Value::Local(loc),
+        StackValue::Temp(reg) => Value::Temp(reg),
+        StackValue::Pop => {
+            ctx.block_state.depth.free(1);
+            let gpr = ctx.block_state.regs.take_scratch_gpr();
+            dynasm!(ctx.asm
+                ; pop Rq(gpr)
+            );
+            Value::Temp(gpr)
+        }
+    }
+}
+
+fn pop_i32_into(ctx: &mut Context, dst: ValueLocation) {
+    let val = pop_i32(ctx);
+    let val_loc = val.location(&ctx.locals);
+    copy_value(ctx, val_loc, dst);
+    free_val(ctx, val);
+}
+
+fn free_val(ctx: &mut Context, val: Value) {
+    match val {
+        Value::Temp(reg) => ctx.block_state.regs.release_scratch_gpr(reg),
+        Value::Local(_) => {}
+    }
+}
+
+/// Puts this value into a register so that it can be efficiently read
+fn into_reg(ctx: &mut Context, val: Value) -> GPR {
+    match val.location(&ctx.locals) {
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            let scratch = ctx.block_state.regs.take_scratch_gpr();
+            dynasm!(ctx.asm
+                ; mov Rq(scratch), [rsp + offset]
+            );
+            scratch
+        }
+        ValueLocation::Reg(reg) => reg,
+    }
+}
+
+/// Puts this value into a temporary register so that operations
+/// on that register don't write to a local.
+fn into_temp_reg(ctx: &mut Context, val: Value) -> GPR {
+    match val {
+        Value::Local(loc) => {
+            let scratch = ctx.block_state.regs.take_scratch_gpr();
+
+            match local_location(&ctx.locals, loc) {
+                ValueLocation::Stack(offset) => {
+                    let offset = adjusted_offset(ctx, offset);
+                    dynasm!(ctx.asm
+                        ; mov Rq(scratch), [rsp + offset]
+                    );
+                }
+                ValueLocation::Reg(reg) => {
+                    dynasm!(ctx.asm
+                        ; mov Rq(scratch), Rq(reg)
+                    );
+                }
+            }
+
+            scratch
+        }
+        Value::Temp(reg) => reg,
+    }
+}
+
+// TODO: For the commutative instructions we can do operands in either
+//       order, so we can choose the operand order that creates the
+//       least unnecessary temps.
 pub fn i32_add(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let op1 = pop_i32(ctx);
-    dynasm!(ctx.asm
-        ; add Rd(op1), Rd(op0)
-    );
-    push_i32(ctx, op1);
-    ctx.regs.release_scratch_gpr(op0);
+    let tmp = pop_i32(ctx);
+    let op1 = into_temp_reg(ctx, tmp);
+    match op0.location(&ctx.locals) {
+        ValueLocation::Reg(reg) => {
+            dynasm!(ctx.asm
+                ; add Rd(op1), Rd(reg)
+            );
+        }
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; add Rd(op1), [rsp + offset]
+            );
+        }
+    }
+    ctx.block_state.stack.push(StackValue::Temp(op1));
+    free_val(ctx, op0);
 }
 
 pub fn i32_sub(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let op1 = pop_i32(ctx);
-    dynasm!(ctx.asm
-        ; sub Rd(op1), Rd(op0)
-    );
-    push_i32(ctx, op1);
-    ctx.regs.release_scratch_gpr(op0);
+    let tmp = pop_i32(ctx);
+    let op1 = into_temp_reg(ctx, tmp);
+    match op0.location(&ctx.locals) {
+        ValueLocation::Reg(reg) => {
+            dynasm!(ctx.asm
+                ; sub Rd(op1), Rd(reg)
+            );
+        }
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; sub Rd(op1), [rsp + offset]
+            );
+        }
+    }
+    ctx.block_state.stack.push(StackValue::Temp(op1));
+    free_val(ctx, op0);
 }
 
 pub fn i32_and(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let op1 = pop_i32(ctx);
-    dynasm!(ctx.asm
-        ; and Rd(op1), Rd(op0)
-    );
-    push_i32(ctx, op1);
-    ctx.regs.release_scratch_gpr(op0);
+    let tmp = pop_i32(ctx);
+    let op1 = into_temp_reg(ctx, tmp);
+    match op0.location(&ctx.locals) {
+        ValueLocation::Reg(reg) => {
+            dynasm!(ctx.asm
+                ; and Rd(op1), Rd(reg)
+            );
+        }
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; and Rd(op1), [rsp + offset]
+            );
+        }
+    }
+    ctx.block_state.stack.push(StackValue::Temp(op1));
+    free_val(ctx, op0);
 }
 
 pub fn i32_or(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let op1 = pop_i32(ctx);
-    dynasm!(ctx.asm
-        ; or Rd(op1), Rd(op0)
-    );
-    push_i32(ctx, op1);
-    ctx.regs.release_scratch_gpr(op0);
+    let tmp = pop_i32(ctx);
+    let op1 = into_temp_reg(ctx, tmp);
+    match op0.location(&ctx.locals) {
+        ValueLocation::Reg(reg) => {
+            dynasm!(ctx.asm
+                ; or Rd(op1), Rd(reg)
+            );
+        }
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; or Rd(op1), [rsp + offset]
+            );
+        }
+    }
+    ctx.block_state.stack.push(StackValue::Temp(op1));
+    free_val(ctx, op0);
 }
 
 pub fn i32_xor(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let op1 = pop_i32(ctx);
-    dynasm!(ctx.asm
-        ; xor Rd(op1), Rd(op0)
-    );
-    push_i32(ctx, op1);
-    ctx.regs.release_scratch_gpr(op0);
+    let tmp = pop_i32(ctx);
+    let op1 = into_temp_reg(ctx, tmp);
+    match op0.location(&ctx.locals) {
+        ValueLocation::Reg(reg) => {
+            dynasm!(ctx.asm
+                ; xor Rd(op1), Rd(reg)
+            );
+        }
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; xor Rd(op1), [rsp + offset]
+            );
+        }
+    }
+    ctx.block_state.stack.push(StackValue::Temp(op1));
+    free_val(ctx, op0);
 }
 
 pub fn i32_mul(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let op1 = pop_i32(ctx);
-    dynasm!(ctx.asm
-        ; imul Rd(op1), Rd(op0)
-    );
-    push_i32(ctx, op1);
-    ctx.regs.release_scratch_gpr(op0);
-}
-
-fn sp_relative_offset(ctx: &mut Context, slot_idx: u32) -> i32 {
-    ((ctx.sp_depth.0 as i32) + slot_idx as i32) * WORD_SIZE as i32
+    let tmp = pop_i32(ctx);
+    let op1 = into_temp_reg(ctx, tmp);
+    match op0.location(&ctx.locals) {
+        ValueLocation::Reg(reg) => {
+            dynasm!(ctx.asm
+                ; imul Rd(op1), Rd(reg)
+            );
+        }
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; imul Rd(op1), [rsp + offset]
+            );
+        }
+    }
+    ctx.block_state.stack.push(StackValue::Temp(op1));
+    free_val(ctx, op0);
 }
 
 pub fn get_local_i32(ctx: &mut Context, local_idx: u32) {
-    let gpr = ctx.regs.take_scratch_gpr();
-    let offset = sp_relative_offset(ctx, local_idx);
-    dynasm!(ctx.asm
-        ; mov Rq(gpr), [rsp + offset]
-    );
-    push_i32(ctx, gpr);
+    push_i32(ctx, Value::Local(local_idx));
 }
 
+// TODO: We can put locals that were spilled to the stack
+//       back into registers here.
 pub fn set_local_i32(ctx: &mut Context, local_idx: u32) {
-    let gpr = pop_i32(ctx);
-    let offset = sp_relative_offset(ctx, local_idx);
-    dynasm!(ctx.asm
-        ; mov [rsp + offset], Rq(gpr)
-    );
-    ctx.regs.release_scratch_gpr(gpr);
+    let val = pop_i32(ctx);
+    let val_loc = val.location(&ctx.locals);
+    let dst_loc = local_location(&ctx.locals, local_idx);
+    copy_value(ctx, val_loc, dst_loc);
+    free_val(ctx, val);
 }
 
+// TODO: Don't store literals at all, roll them into `Value`
 pub fn literal_i32(ctx: &mut Context, imm: i32) {
-    let gpr = ctx.regs.take_scratch_gpr();
+    let gpr = ctx.block_state.regs.take_scratch_gpr();
     dynasm!(ctx.asm
         ; mov Rd(gpr), imm
     );
-    push_i32(ctx, gpr);
+    push_i32(ctx, Value::Temp(gpr));
 }
 
 pub fn relop_eq_i32(ctx: &mut Context) {
     let right = pop_i32(ctx);
     let left = pop_i32(ctx);
-    let result = ctx.regs.take_scratch_gpr();
-    dynasm!(ctx.asm
-        ; xor Rq(result), Rq(result)
-        ; cmp Rd(left), Rd(right)
-        ; sete Rb(result)
-    );
-    push_i32(ctx, result);
-    ctx.regs.release_scratch_gpr(left);
-    ctx.regs.release_scratch_gpr(right);
+    let result = ctx.block_state.regs.take_scratch_gpr();
+    let lreg = into_reg(ctx, left);
+    match right.location(&ctx.locals) {
+        ValueLocation::Stack(offset) => {
+            let offset = adjusted_offset(ctx, offset);
+            dynasm!(ctx.asm
+                ; xor Rq(result), Rq(result)
+                ; cmp Rd(lreg), [rsp + offset]
+                ; sete Rb(result)
+            );
+        }
+        ValueLocation::Reg(rreg) => {
+            dynasm!(ctx.asm
+                ; xor Rq(result), Rq(result)
+                ; cmp Rd(lreg), Rd(rreg)
+                ; sete Rb(result)
+            );
+        }
+    }
+    push_i32(ctx, Value::Temp(result));
+    free_val(ctx, left);
+    free_val(ctx, right);
 }
 
 /// Pops i32 predicate and branches to the specified label
 /// if the predicate is equal to zero.
 pub fn pop_and_breq(ctx: &mut Context, label: Label) {
-    let predicate = pop_i32(ctx);
+    let val = pop_i32(ctx);
+    let predicate = into_temp_reg(ctx, val);
     dynasm!(ctx.asm
         ; test Rd(predicate), Rd(predicate)
         ; je =>label.0
     );
-    ctx.regs.release_scratch_gpr(predicate);
+    ctx.block_state.regs.release_scratch_gpr(predicate);
 }
 
 /// Branch unconditionally to the specified label.
@@ -388,122 +629,246 @@ pub fn br(ctx: &mut Context, label: Label) {
 }
 
 pub fn prepare_return_value(ctx: &mut Context) {
-    let ret_gpr = pop_i32(ctx);
-    if ret_gpr != RAX {
-        dynasm!(ctx.asm
-            ; mov Rq(RAX), Rq(ret_gpr)
-        );
-        ctx.regs.release_scratch_gpr(ret_gpr);
-    }
+    pop_i32_into(ctx, ValueLocation::Reg(RAX));
 }
 
-pub fn copy_incoming_arg(ctx: &mut Context, frame_size: u32, arg_pos: u32) {
-    let loc = abi_loc_for_arg(arg_pos);
-
-    // First, ensure the argument is in a register.
-    let reg = match loc {
-        ArgLocation::Reg(reg) => reg,
-        ArgLocation::Stack(offset) => {
-            assert!(
-                ctx.regs.scratch_gprs.is_free(RAX),
-                "we assume that RAX can be used as a scratch register for now",
-            );
-            let offset = offset + (frame_size * WORD_SIZE) as i32;
-            dynasm!(ctx.asm
-                ; mov Rq(RAX), [rsp + offset]
-            );
-            RAX
+fn copy_value(ctx: &mut Context, src: ValueLocation, dst: ValueLocation) {
+    match (src, dst) {
+        (ValueLocation::Stack(in_offset), ValueLocation::Stack(out_offset)) => {
+            let in_offset = adjusted_offset(ctx, in_offset);
+            let out_offset = adjusted_offset(ctx, out_offset);
+            if in_offset != out_offset {
+                let gpr = ctx.block_state.regs.take_scratch_gpr();
+                dynasm!(ctx.asm
+                    ; mov Rq(gpr), [rsp + in_offset]
+                    ; mov [rsp + out_offset], Rq(gpr)
+                );
+                ctx.block_state.regs.release_scratch_gpr(gpr);
+            }
         }
-    };
-
-    // And then move a value from a register into local variable area on the stack.
-    let offset = sp_relative_offset(ctx, arg_pos);
-    dynasm!(ctx.asm
-        ; mov [rsp + offset], Rq(reg)
-    );
+        (ValueLocation::Reg(in_reg), ValueLocation::Stack(out_offset)) => {
+            let out_offset = adjusted_offset(ctx, out_offset);
+            dynasm!(ctx.asm
+                ; mov [rsp + out_offset], Rq(in_reg)
+            );
+        }
+        (ValueLocation::Stack(in_offset), ValueLocation::Reg(out_reg)) => {
+            let in_offset = adjusted_offset(ctx, in_offset);
+            dynasm!(ctx.asm
+                ; mov Rq(out_reg), [rsp + in_offset]
+            );
+        }
+        (ValueLocation::Reg(in_reg), ValueLocation::Reg(out_reg)) => {
+            if in_reg != out_reg {
+                dynasm!(ctx.asm
+                    ; mov Rq(out_reg), Rq(in_reg)
+                );
+            }
+        }
+    }
 }
 
 #[must_use]
-fn pass_outgoing_args(ctx: &mut Context, arity: u32) -> i32 {
-    let mut stack_args = Vec::with_capacity((arity as usize).saturating_sub(ARGS_IN_GPRS.len()));
-    for arg_pos in (0..arity).rev() {
-        ctx.sp_depth.free(1);
+pub struct CallCleanup {
+    restore_registers: Vec<GPR>,
+    stack_depth: i32,
+}
 
-        let loc = abi_loc_for_arg(arg_pos);
-        match loc {
-            ArgLocation::Reg(gpr) => {
-                dynasm!(ctx.asm
-                    ; pop Rq(gpr)
-                );
+/// Make sure that any argument registers that will be used by the call are free
+/// by storing them to the stack.
+///
+/// Unfortunately, we can't elide this store if we're just passing arguments on
+/// because these registers are caller-saved and so the callee can use them as
+/// scratch space.
+fn free_arg_registers(ctx: &mut Context, count: u32) {
+    if count == 0 {
+        return;
+    }
+
+    for i in 0..ctx.locals.locs.len() {
+        match ctx.locals.locs[i] {
+            ValueLocation::Reg(reg) => {
+                if ARGS_IN_GPRS.contains(&reg) {
+                    let offset = adjusted_offset(ctx, (i as u32 * WORD_SIZE) as _);
+                    dynasm!(ctx.asm
+                        ; mov [rsp + offset], Rq(reg)
+                    );
+                    ctx.locals.locs[i] = ValueLocation::Stack(offset);
+                }
             }
-            ArgLocation::Stack(_) => {
-                let gpr = ctx.regs.take_scratch_gpr();
+            _ => {}
+        }
+    }
+}
+
+fn free_return_register(ctx: &mut Context, count: u32) {
+    if count == 0 {
+        return;
+    }
+
+    for stack_val in &mut ctx.block_state.stack {
+        match stack_val.location(&ctx.locals) {
+            // For now it's impossible for a local to be in RAX but that might be
+            // possible in the future, so we check both cases.
+            Some(ValueLocation::Reg(RAX)) => {
+                let scratch = ctx.block_state.regs.take_scratch_gpr();
                 dynasm!(ctx.asm
-                    ; pop Rq(gpr)
+                    ; mov Rq(scratch), rax
                 );
-                stack_args.push(gpr);
+                *stack_val = StackValue::Temp(scratch);
             }
+            _ => {}
+        }
+    }
+}
+
+// TODO: Use `ArrayVec`?
+/// Saves volatile (i.e. caller-saved) registers before a function call, if they are used.
+fn save_volatile(ctx: &mut Context) -> Vec<GPR> {
+    let mut out = vec![];
+
+    // TODO: If there are no `StackValue::Pop`s that need to be popped
+    //       before we reach our `Temp` value, we can set the `StackValue`
+    //       for the register to be restored to `StackValue::Pop` (and
+    //       release the register!) instead of restoring it.
+    for &reg in SCRATCH_REGS.iter() {
+        if !ctx.block_state.regs.is_free(reg) {
+            dynasm!(ctx.asm
+                ; push Rq(reg)
+            );
+            out.push(reg);
         }
     }
 
-    let num_stack_args = stack_args.len() as i32;
-    dynasm!(ctx.asm
-        ; sub rsp, num_stack_args
-    );
-    for (stack_slot, gpr) in stack_args.into_iter().rev().enumerate() {
-        let offset = (stack_slot * WORD_SIZE as usize) as i32;
+    out
+}
+
+/// Write the arguments to the callee to the registers and the stack using the SystemV
+/// calling convention.
+fn pass_outgoing_args(ctx: &mut Context, arity: u32) -> CallCleanup {
+    let num_stack_args = (arity as usize).saturating_sub(ARGS_IN_GPRS.len()) as i32;
+
+    let out = CallCleanup {
+        stack_depth: num_stack_args,
+        restore_registers: save_volatile(ctx),
+    };
+
+    // We pop stack arguments first - arguments are RTL
+    if num_stack_args > 0 {
+        let size = num_stack_args * WORD_SIZE as i32;
+
+        // Reserve space for the outgoing stack arguments (so we don't
+        // stomp on any locals or the value stack).
         dynasm!(ctx.asm
-            ; mov [rsp + offset], Rq(gpr)
+            ; sub rsp, size
         );
-        ctx.regs.release_scratch_gpr(gpr);
+        ctx.block_state.depth.reserve(num_stack_args as u32);
+
+        for stack_slot in (0..num_stack_args).rev() {
+            // Since the stack offset is from the bottom of the locals
+            // and we want to start from the actual RSP (so `offset = 0`
+            // writes to `[rsp]`), we subtract our current depth.
+            //
+            // We might want to do this in the future by having a separate
+            // `AbsoluteValueLocation` and `RelativeValueLocation`.
+            let offset =
+                stack_slot * WORD_SIZE as i32 - ctx.block_state.depth.0 as i32 * WORD_SIZE as i32;
+            pop_i32_into(ctx, ValueLocation::Stack(offset));
+        }
     }
 
-    num_stack_args
+    for reg in ARGS_IN_GPRS[..(arity as usize).min(ARGS_IN_GPRS.len())]
+        .iter()
+        .rev()
+    {
+        pop_i32_into(ctx, ValueLocation::Reg(*reg));
+    }
+
+    out
 }
 
-fn post_call_cleanup(ctx: &mut Context, num_stack_args: i32) {
-    dynasm!(ctx.asm
-        ; add rsp, num_stack_args
-    );
+/// Frees up the stack space used for stack-passed arguments and restores the value
+/// of volatile (i.e. caller-saved) registers to the state that they were in before
+/// the call.
+fn post_call_cleanup(ctx: &mut Context, mut cleanup: CallCleanup) {
+    if cleanup.stack_depth > 0 {
+        let size = cleanup.stack_depth * WORD_SIZE as i32;
+        dynasm!(ctx.asm
+            ; add rsp, size
+        );
+    }
+
+    for reg in cleanup.restore_registers.drain(..).rev() {
+        dynasm!(ctx.asm
+            ; pop Rq(reg)
+        );
+    }
 }
 
+/// Call a function with the given index
 pub fn call_direct(ctx: &mut Context, index: u32, arg_arity: u32, return_arity: u32) {
-    assert!(return_arity == 0 || return_arity == 1);
+    assert!(
+        return_arity == 0 || return_arity == 1,
+        "We don't support multiple return yet"
+    );
 
-    let num_stack_args = pass_outgoing_args(ctx, arg_arity);
+    free_arg_registers(ctx, arg_arity);
+    free_return_register(ctx, return_arity);
+
+    let cleanup = pass_outgoing_args(ctx, arg_arity);
 
     let label = &ctx.func_starts[index as usize].1;
     dynasm!(ctx.asm
         ; call =>*label
     );
 
-    post_call_cleanup(ctx, num_stack_args);
-
-    if return_arity == 1 {
-        dynasm!(ctx.asm
-            ; push rax
-        );
-        ctx.sp_depth.reserve(1);
-    }
+    post_call_cleanup(ctx, cleanup);
 }
 
-pub fn prologue(ctx: &mut Context, stack_slots: u32) {
-    let stack_slots = stack_slots;
+// TODO: Reserve space to store RBX, RBP, and R12..R15 so we can use them
+//       as scratch registers
+// TODO: Allow use of unused argument registers as scratch registers.
+/// Writes the function prologue and stores the arguments as locals
+pub fn start_function(ctx: &mut Context, arguments: u32, locals: u32) {
+    let reg_args = &ARGS_IN_GPRS[..(arguments as usize).min(ARGS_IN_GPRS.len())];
+
+    // We need space to store the register arguments if we need to call a function
+    // and overwrite these registers so we add `reg_args.len()`
+    let locals = locals + reg_args.len() as u32;
     // Align stack slots to the nearest even number. This is required
     // by x86-64 ABI.
-    let aligned_stack_slots = (stack_slots + 1) & !1;
-
+    let aligned_stack_slots = (locals + 1) & !1;
     let framesize: i32 = aligned_stack_slots as i32 * WORD_SIZE as i32;
+
+    ctx.locals.locs = reg_args
+        .iter()
+        .cloned()
+        .map(ValueLocation::Reg)
+        .chain(
+            (0..arguments.saturating_sub(ARGS_IN_GPRS.len() as _))
+                // We add 2 here because 1 stack slot is used for the stack pointer and another is
+                // used for the return address. It's a magic number but there's not really a way
+                // around this.
+                .map(|arg_i| ValueLocation::Stack(((arg_i + 2) * WORD_SIZE) as i32 + framesize)),
+        )
+        .collect();
+
     dynasm!(ctx.asm
         ; push rbp
         ; mov rbp, rsp
-        ; sub rsp, framesize
     );
-    ctx.sp_depth.reserve(aligned_stack_slots - stack_slots);
+
+    if framesize > 0 {
+        dynasm!(ctx.asm
+            ; sub rsp, framesize
+        );
+    }
 }
 
+/// Writes the function epilogue, restoring the stack pointer and returning to the
+/// caller.
 pub fn epilogue(ctx: &mut Context) {
-    // We don't need to clean up the stack - `rsp` is restored and
+    // We don't need to clean up the stack - RSP is restored and
     // the calling function has its own register stack and will
     // stomp on the registers from our stack if necessary.
     dynasm!(ctx.asm

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -118,6 +118,8 @@ enum ValueLocation {
     /// first local, and so will have to be adjusted with `adjusted_offset`
     /// before reading (as RSP may have been changed by `push`/`pop`).
     Stack(i32),
+    /// Value is a literal (TODO: Support more than just `i32`)
+    Immediate(i32),
 }
 
 // TODO: This assumes only system-v calling convention.
@@ -229,13 +231,22 @@ impl TranslatedCodeSection {
 enum Value {
     Local(u32),
     Temp(GPR),
+    Immediate(i32),
 }
 
 impl Value {
+    fn immediate(&self) -> Option<i32> {
+        match *self {
+            Value::Immediate(i) => Some(i),
+            _ => None,
+        }
+    }
+
     fn location(&self, locals: &Locals) -> ValueLocation {
         match *self {
             Value::Local(loc) => local_location(locals, loc),
             Value::Temp(reg) => ValueLocation::Reg(reg),
+            Value::Immediate(reg) => ValueLocation::Immediate(reg),
         }
     }
 }
@@ -244,6 +255,7 @@ impl Value {
 enum StackValue {
     Local(u32),
     Temp(GPR),
+    Immediate(i32),
     Pop,
 }
 
@@ -251,6 +263,7 @@ impl StackValue {
     fn location(&self, locals: &Locals) -> Option<ValueLocation> {
         match *self {
             StackValue::Local(loc) => Some(local_location(locals, loc)),
+            StackValue::Immediate(i) => Some(ValueLocation::Immediate(i)),
             StackValue::Temp(reg) => Some(ValueLocation::Reg(reg)),
             StackValue::Pop => None,
         }
@@ -266,7 +279,7 @@ struct Locals {
 #[derive(Default, Clone)]
 pub struct BlockState {
     stack: Stack,
-    depth: StackDepth,
+    pub depth: StackDepth,
     regs: Registers,
 }
 
@@ -331,6 +344,37 @@ pub fn current_block_state(ctx: &Context) -> BlockState {
     ctx.block_state.clone()
 }
 
+pub fn return_from_block(ctx: &mut Context, new_depth: StackDepth) {
+    let diff = ((ctx.block_state.depth.0 - new_depth.0) * WORD_SIZE) as i32;
+
+    if let Some(loc) = ctx.block_state.stack.last().unwrap().location(&ctx.locals) {
+        match loc {
+            ValueLocation::Reg(r) => {
+                dynasm!(ctx.asm
+                    ; push Rq(r)
+                );
+            }
+            ValueLocation::Stack(offset) => {
+                let offset = adjusted_offset(ctx, offset);
+                dynasm!(ctx.asm
+                    ; push QWORD [rsp + offset]
+                );
+            }
+            ValueLocation::Immediate(imm) => {
+                dynasm!(ctx.asm
+                    ; push imm
+                );
+            }
+        }
+    }
+    // If `location` is `None` then we don't need to do anything.
+}
+
+pub fn push_block_return_value(ctx: &mut Context) {
+    ctx.block_state.depth.reserve(1);
+    ctx.block_state.stack.push(StackValue::Pop);
+}
+
 pub fn restore_block_state(ctx: &mut Context, block_state: BlockState) {
     ctx.block_state = block_state;
 }
@@ -342,6 +386,7 @@ pub fn push_return_value(ctx: &mut Context) {
 fn push_i32(ctx: &mut Context, value: Value) {
     let stack_loc = match value {
         Value::Local(loc) => StackValue::Local(loc),
+        Value::Immediate(i) => StackValue::Immediate(i),
         Value::Temp(gpr) => {
             if ctx.block_state.regs.free_scratch() >= 1 {
                 StackValue::Temp(gpr)
@@ -362,6 +407,7 @@ fn push_i32(ctx: &mut Context, value: Value) {
 fn pop_i32(ctx: &mut Context) -> Value {
     match ctx.block_state.stack.pop().expect("Stack is empty") {
         StackValue::Local(loc) => Value::Local(loc),
+        StackValue::Immediate(i) => Value::Immediate(i),
         StackValue::Temp(reg) => Value::Temp(reg),
         StackValue::Pop => {
             ctx.block_state.depth.free(1);
@@ -384,7 +430,7 @@ fn pop_i32_into(ctx: &mut Context, dst: ValueLocation) {
 fn free_val(ctx: &mut Context, val: Value) {
     match val {
         Value::Temp(reg) => ctx.block_state.regs.release_scratch_gpr(reg),
-        Value::Local(_) => {}
+        Value::Local(_) | Value::Immediate(_) => {}
     }
 }
 
@@ -396,6 +442,13 @@ fn into_reg(ctx: &mut Context, val: Value) -> GPR {
             let scratch = ctx.block_state.regs.take_scratch_gpr();
             dynasm!(ctx.asm
                 ; mov Rq(scratch), [rsp + offset]
+            );
+            scratch
+        }
+        ValueLocation::Immediate(i) => {
+            let scratch = ctx.block_state.regs.take_scratch_gpr();
+            dynasm!(ctx.asm
+                ; mov Rq(scratch), i
             );
             scratch
         }
@@ -422,7 +475,19 @@ fn into_temp_reg(ctx: &mut Context, val: Value) -> GPR {
                         ; mov Rq(scratch), Rq(reg)
                     );
                 }
+                ValueLocation::Immediate(_) => {
+                    panic!("We shouldn't be storing immediates in locals for now")
+                }
             }
+
+            scratch
+        }
+        Value::Immediate(i) => {
+            let scratch = ctx.block_state.regs.take_scratch_gpr();
+
+            dynasm!(ctx.asm
+                ; mov Rq(scratch), i
+            );
 
             scratch
         }
@@ -430,34 +495,68 @@ fn into_temp_reg(ctx: &mut Context, val: Value) -> GPR {
     }
 }
 
-// TODO: For the commutative instructions we can do operands in either
-//       order, so we can choose the operand order that creates the
-//       least unnecessary temps.
-pub fn i32_add(ctx: &mut Context) {
-    let op0 = pop_i32(ctx);
-    let tmp = pop_i32(ctx);
-    let op1 = into_temp_reg(ctx, tmp);
-    match op0.location(&ctx.locals) {
-        ValueLocation::Reg(reg) => {
-            dynasm!(ctx.asm
-                ; add Rd(op1), Rd(reg)
-            );
-        }
-        ValueLocation::Stack(offset) => {
-            let offset = adjusted_offset(ctx, offset);
-            dynasm!(ctx.asm
-                ; add Rd(op1), [rsp + offset]
-            );
+macro_rules! commutative_binop {
+    ($name:ident, $instr:ident, $const_fallback:expr) => {
+        pub fn $name(ctx: &mut Context) {
+            let op0 = pop_i32(ctx);
+            let op1 = pop_i32(ctx);
+
+            if let Some(i1) = op1.immediate() {
+                if let Some(i0) = op0.immediate() {
+                    ctx.block_state.stack.push(StackValue::Immediate($const_fallback(i1, i0)));
+                    return;
+                }
+            }
+
+            let (op1, op0) = match op1 {
+                Value::Temp(reg) => (reg, op0),
+                _ => (into_temp_reg(ctx, op0), op1),
+            };
+
+            match op0.location(&ctx.locals) {
+                ValueLocation::Reg(reg) => {
+                    dynasm!(ctx.asm
+                        ; $instr Rd(op1), Rd(reg)
+                    );
+                }
+                ValueLocation::Stack(offset) => {
+                    let offset = adjusted_offset(ctx, offset);
+                    dynasm!(ctx.asm
+                        ; $instr Rd(op1), [rsp + offset]
+                    );
+                }
+                ValueLocation::Immediate(offset) => {
+                    let offset = adjusted_offset(ctx, offset);
+                    dynasm!(ctx.asm
+                        ; $instr Rd(op1), [rsp + offset]
+                    );
+                }
+            }
+
+            ctx.block_state.stack.push(StackValue::Temp(op1));
+            free_val(ctx, op0);
         }
     }
-    ctx.block_state.stack.push(StackValue::Temp(op1));
-    free_val(ctx, op0);
 }
+
+commutative_binop!(i32_add, add, |a, b| a + b);
+commutative_binop!(i32_and, and, |a, b| a & b);
+commutative_binop!(i32_or, or, |a, b| a | b);
+commutative_binop!(i32_xor, xor, |a, b| a ^ b);
+commutative_binop!(i32_mul, imul, |a, b| a * b);
 
 pub fn i32_sub(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
-    let tmp = pop_i32(ctx);
-    let op1 = into_temp_reg(ctx, tmp);
+    let op1 = pop_i32(ctx);
+
+    if let Some(i1) = op1.immediate() {
+        if let Some(i0) = op0.immediate() {
+            ctx.block_state.stack.push(StackValue::Immediate(i1 - i0));
+            return;
+        }
+    }
+
+    let op1 = into_temp_reg(ctx, op1);
     match op0.location(&ctx.locals) {
         ValueLocation::Reg(reg) => {
             dynasm!(ctx.asm
@@ -470,91 +569,14 @@ pub fn i32_sub(ctx: &mut Context) {
                 ; sub Rd(op1), [rsp + offset]
             );
         }
-    }
-    ctx.block_state.stack.push(StackValue::Temp(op1));
-    free_val(ctx, op0);
-}
-
-pub fn i32_and(ctx: &mut Context) {
-    let op0 = pop_i32(ctx);
-    let tmp = pop_i32(ctx);
-    let op1 = into_temp_reg(ctx, tmp);
-    match op0.location(&ctx.locals) {
-        ValueLocation::Reg(reg) => {
-            dynasm!(ctx.asm
-                ; and Rd(op1), Rd(reg)
-            );
-        }
-        ValueLocation::Stack(offset) => {
+        ValueLocation::Immediate(offset) => {
             let offset = adjusted_offset(ctx, offset);
             dynasm!(ctx.asm
-                ; and Rd(op1), [rsp + offset]
+                ; sub Rd(op1), [rsp + offset]
             );
         }
     }
-    ctx.block_state.stack.push(StackValue::Temp(op1));
-    free_val(ctx, op0);
-}
 
-pub fn i32_or(ctx: &mut Context) {
-    let op0 = pop_i32(ctx);
-    let tmp = pop_i32(ctx);
-    let op1 = into_temp_reg(ctx, tmp);
-    match op0.location(&ctx.locals) {
-        ValueLocation::Reg(reg) => {
-            dynasm!(ctx.asm
-                ; or Rd(op1), Rd(reg)
-            );
-        }
-        ValueLocation::Stack(offset) => {
-            let offset = adjusted_offset(ctx, offset);
-            dynasm!(ctx.asm
-                ; or Rd(op1), [rsp + offset]
-            );
-        }
-    }
-    ctx.block_state.stack.push(StackValue::Temp(op1));
-    free_val(ctx, op0);
-}
-
-pub fn i32_xor(ctx: &mut Context) {
-    let op0 = pop_i32(ctx);
-    let tmp = pop_i32(ctx);
-    let op1 = into_temp_reg(ctx, tmp);
-    match op0.location(&ctx.locals) {
-        ValueLocation::Reg(reg) => {
-            dynasm!(ctx.asm
-                ; xor Rd(op1), Rd(reg)
-            );
-        }
-        ValueLocation::Stack(offset) => {
-            let offset = adjusted_offset(ctx, offset);
-            dynasm!(ctx.asm
-                ; xor Rd(op1), [rsp + offset]
-            );
-        }
-    }
-    ctx.block_state.stack.push(StackValue::Temp(op1));
-    free_val(ctx, op0);
-}
-
-pub fn i32_mul(ctx: &mut Context) {
-    let op0 = pop_i32(ctx);
-    let tmp = pop_i32(ctx);
-    let op1 = into_temp_reg(ctx, tmp);
-    match op0.location(&ctx.locals) {
-        ValueLocation::Reg(reg) => {
-            dynasm!(ctx.asm
-                ; imul Rd(op1), Rd(reg)
-            );
-        }
-        ValueLocation::Stack(offset) => {
-            let offset = adjusted_offset(ctx, offset);
-            dynasm!(ctx.asm
-                ; imul Rd(op1), [rsp + offset]
-            );
-        }
-    }
     ctx.block_state.stack.push(StackValue::Temp(op1));
     free_val(ctx, op0);
 }
@@ -573,37 +595,67 @@ pub fn set_local_i32(ctx: &mut Context, local_idx: u32) {
     free_val(ctx, val);
 }
 
-// TODO: Don't store literals at all, roll them into `Value`
 pub fn literal_i32(ctx: &mut Context, imm: i32) {
-    let gpr = ctx.block_state.regs.take_scratch_gpr();
-    dynasm!(ctx.asm
-        ; mov Rd(gpr), imm
-    );
-    push_i32(ctx, Value::Temp(gpr));
+    push_i32(ctx, Value::Immediate(imm));
 }
 
 pub fn relop_eq_i32(ctx: &mut Context) {
     let right = pop_i32(ctx);
     let left = pop_i32(ctx);
     let result = ctx.block_state.regs.take_scratch_gpr();
-    let lreg = into_reg(ctx, left);
-    match right.location(&ctx.locals) {
-        ValueLocation::Stack(offset) => {
-            let offset = adjusted_offset(ctx, offset);
-            dynasm!(ctx.asm
-                ; xor Rq(result), Rq(result)
-                ; cmp Rd(lreg), [rsp + offset]
-                ; sete Rb(result)
-            );
+
+    if let Some(i) = left.immediate() {
+        match right.location(&ctx.locals) {
+            ValueLocation::Stack(offset) => {
+                let offset = adjusted_offset(ctx, offset);
+                dynasm!(ctx.asm
+                    ; xor Rq(result), Rq(result)
+                    ; cmp DWORD [rsp + offset], i
+                    ; sete Rb(result)
+                );
+            }
+            ValueLocation::Reg(rreg) => {
+                dynasm!(ctx.asm
+                    ; xor Rq(result), Rq(result)
+                    ; cmp Rd(rreg), i
+                    ; sete Rb(result)
+                );
+            }
+            ValueLocation::Immediate(right) => {
+                let is_equal = if i == right { 1i8 } else { 0 };
+                dynasm!(ctx.asm
+                    ; mov Rb(result), is_equal
+                );
+            }
         }
-        ValueLocation::Reg(rreg) => {
-            dynasm!(ctx.asm
-                ; xor Rq(result), Rq(result)
-                ; cmp Rd(lreg), Rd(rreg)
-                ; sete Rb(result)
-            );
+    } else {
+        let lreg = into_reg(ctx, left);
+        match right.location(&ctx.locals) {
+            ValueLocation::Stack(offset) => {
+                let offset = adjusted_offset(ctx, offset);
+                dynasm!(ctx.asm
+                    ; xor Rq(result), Rq(result)
+                    ; cmp Rd(lreg), [rsp + offset]
+                    ; sete Rb(result)
+                );
+            }
+            ValueLocation::Reg(rreg) => {
+                dynasm!(ctx.asm
+                    ; xor Rq(result), Rq(result)
+                    ; cmp Rd(lreg), Rd(rreg)
+                    ; sete Rb(result)
+                );
+            }
+            ValueLocation::Immediate(i) => {
+                dynasm!(ctx.asm
+                    ; xor Rq(result), Rq(result)
+                    ; cmp Rd(lreg), i
+                    ; sete Rb(result)
+                );
+            }
         }
     }
+
     push_i32(ctx, Value::Temp(result));
     free_val(ctx, left);
     free_val(ctx, right);
@@ -652,6 +704,12 @@ fn copy_value(ctx: &mut Context, src: ValueLocation, dst: ValueLocation) {
                 ; mov [rsp + out_offset], Rq(in_reg)
             );
         }
+        (ValueLocation::Immediate(i), ValueLocation::Stack(out_offset)) => {
+            let out_offset = adjusted_offset(ctx, out_offset);
+            dynasm!(ctx.asm
+                ; mov DWORD [rsp + out_offset], i
+            );
+        }
         (ValueLocation::Stack(in_offset), ValueLocation::Reg(out_reg)) => {
             let in_offset = adjusted_offset(ctx, in_offset);
             dynasm!(ctx.asm
@@ -665,6 +723,12 @@ fn copy_value(ctx: &mut Context, src: ValueLocation, dst: ValueLocation) {
                 );
             }
         }
+        (ValueLocation::Immediate(i), ValueLocation::Reg(out_reg)) => {
+            dynasm!(ctx.asm
+                ; mov Rq(out_reg), i
+            );
+        }
+        (_, ValueLocation::Immediate(_)) => panic!("Tried to copy to an immediate value!"),
     }
 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -419,10 +419,33 @@ fn pop_i32(ctx: &mut Context) -> Value {
 }
 
 fn pop_i32_into(ctx: &mut Context, dst: ValueLocation) {
-    let val = pop_i32(ctx);
-    let val_loc = val.location(&ctx.locals);
-    copy_value(ctx, val_loc, dst);
-    free_val(ctx, val);
+    let to_move = match ctx.block_state.stack.pop().expect("Stack is empty") {
+        StackValue::Local(loc) => Value::Local(loc),
+        StackValue::Immediate(i) => Value::Immediate(i),
+        StackValue::Temp(reg) => Value::Temp(reg),
+        StackValue::Pop => {
+            ctx.block_state.depth.free(1);
+            match dst {
+                ValueLocation::Reg(r) => dynasm!(ctx.asm
+                    ; pop Rq(r)
+                ),
+                ValueLocation::Stack(offset) => {
+                    let offset = adjusted_offset(ctx, offset);
+                    dynasm!(ctx.asm
+                        ; pop QWORD [rsp + offset]
+                    )
+                }
+                ValueLocation::Immediate(_) => panic!("Tried to write to literal!"),
+            }
+
+            // DO NOT DO A `copy_val`
+            return;
+        }
+    };
+
+    let src = to_move.location(&ctx.locals);
+    copy_value(ctx, src, dst);
+    free_val(ctx, to_move);
 }
 
 fn free_val(ctx: &mut Context, val: Value) {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -368,8 +368,9 @@ pub fn copy_incoming_arg(ctx: &mut Context, frame_size: u32, arg_pos: u32) {
     );
 }
 
-pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
-    let mut stack_args = vec![];
+#[must_use]
+fn pass_outgoing_args(ctx: &mut Context, arity: u32) -> i32 {
+    let mut stack_args = Vec::with_capacity((arity as usize).saturating_sub(ARGS_IN_GPRS.len()));
     for arg_pos in (0..arity).rev() {
         ctx.sp_depth.free(1);
 
@@ -390,21 +391,38 @@ pub fn pass_outgoing_args(ctx: &mut Context, arity: u32) {
         }
     }
 
-    for gpr in stack_args {
+    let num_stack_args = stack_args.len() as i32;
+    dynasm!(ctx.asm
+        ; sub rsp, num_stack_args
+    );
+    for (stack_slot, gpr) in stack_args.into_iter().rev().enumerate() {
+        let offset = (stack_slot * WORD_SIZE as usize) as i32;
         dynasm!(ctx.asm
-            ; push Rq(gpr)
+            ; mov [rsp + offset], Rq(gpr)
         );
         ctx.regs.release_scratch_gpr(gpr);
     }
+
+    num_stack_args
 }
 
-pub fn call_direct(ctx: &mut Context, index: u32, return_arity: u32) {
+fn post_call_cleanup(ctx: &mut Context, num_stack_args: i32) {
+    dynasm!(ctx.asm
+        ; add rsp, num_stack_args
+    );
+}
+
+pub fn call_direct(ctx: &mut Context, index: u32, arg_arity: u32, return_arity: u32) {
     assert!(return_arity == 0 || return_arity == 1);
 
-    let label = &ctx.func_defs[index as usize].label;
+    let num_stack_args = pass_outgoing_args(ctx, arg_arity);
+
+    let label = &ctx.func_starts[index as usize].1;
     dynasm!(ctx.asm
         ; call =>*label
     );
+
+    post_call_cleanup(ctx, num_stack_args);
 
     if return_arity == 1 {
         dynasm!(ctx.asm

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)] // for now
 
+// Since we want this to be linear-time, we never want to iterate over a `Vec`. `ArrayVec`s have a hard,
+// small maximum size and so we can consider iterating over them to be essentially constant-time.
+use arrayvec::ArrayVec;
+
 use dynasmrt::x64::Assembler;
 use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, ExecutableBuffer};
 use error::Error;
@@ -188,7 +192,7 @@ impl CodeGenSession {
             asm: &mut self.assembler,
             func_starts: &self.func_starts,
             block_state: Default::default(),
-            locals: Default::default(),
+            original_locals: Default::default(),
         }
     }
 
@@ -244,7 +248,7 @@ impl Value {
 
     fn location(&self, locals: &Locals) -> ValueLocation {
         match *self {
-            Value::Local(loc) => local_location(locals, loc),
+            Value::Local(loc) => locals.get(loc),
             Value::Temp(reg) => ValueLocation::Reg(reg),
             Value::Immediate(reg) => ValueLocation::Immediate(reg),
         }
@@ -262,7 +266,7 @@ enum StackValue {
 impl StackValue {
     fn location(&self, locals: &Locals) -> Option<ValueLocation> {
         match *self {
-            StackValue::Local(loc) => Some(local_location(locals, loc)),
+            StackValue::Local(loc) => Some(locals.get(loc)),
             StackValue::Immediate(i) => Some(ValueLocation::Immediate(i)),
             StackValue::Temp(reg) => Some(ValueLocation::Reg(reg)),
             StackValue::Pop => None,
@@ -270,10 +274,30 @@ impl StackValue {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Locals {
-    // TODO: Use `ArrayVec` since we have a hard maximum (the number of registers)
-    locs: Vec<ValueLocation>,
+    register_arguments: ArrayVec<[ValueLocation; ARGS_IN_GPRS.len()]>,
+    num_stack_args: u32,
+    num_local_stack_slots: u32,
+}
+
+impl Locals {
+    fn get(&self, index: u32) -> ValueLocation {
+        self.register_arguments
+            .get(index as usize)
+            .cloned()
+            .unwrap_or_else(|| {
+                let stack_index = index - self.register_arguments.len() as u32;
+                if stack_index < self.num_stack_args {
+                    ValueLocation::Stack(
+                        ((stack_index + self.num_local_stack_slots + 2) * WORD_SIZE) as _,
+                    )
+                } else {
+                    let stack_index = stack_index - self.num_stack_args;
+                    ValueLocation::Stack((stack_index * WORD_SIZE) as _)
+                }
+            })
+    }
 }
 
 #[derive(Default, Clone)]
@@ -281,20 +305,14 @@ pub struct BlockState {
     stack: Stack,
     pub depth: StackDepth,
     regs: Registers,
+    /// This is the _current_ locals, since we can shuffle them about during function calls.
+    /// We will restore this to be the same state as the `Locals` in `Context` at the end
+    /// of a block.
+    locals: Locals,
 }
 
 fn adjusted_offset(ctx: &mut Context, offset: i32) -> i32 {
     (ctx.block_state.depth.0 * WORD_SIZE) as i32 + offset
-}
-
-fn local_location(locals: &Locals, index: u32) -> ValueLocation {
-    locals
-        .locs
-        .get(index as usize)
-        .cloned()
-        .unwrap_or(ValueLocation::Stack(
-            (index.saturating_sub(ARGS_IN_GPRS.len() as u32) * WORD_SIZE) as _,
-        ))
 }
 
 type Stack = Vec<StackValue>;
@@ -304,7 +322,7 @@ pub struct Context<'a> {
     func_starts: &'a Vec<(Option<AssemblyOffset>, DynamicLabel)>,
     /// Each push and pop on the value stack increments or decrements this value by 1 respectively.
     block_state: BlockState,
-    locals: Locals,
+    original_locals: Locals,
 }
 
 impl<'a> Context<'a> {}
@@ -345,40 +363,34 @@ pub fn current_block_state(ctx: &Context) -> BlockState {
 }
 
 pub fn return_from_block(ctx: &mut Context) {
-    if let Some(loc) = ctx.block_state.stack.last().unwrap().location(&ctx.locals) {
-        match loc {
-            ValueLocation::Reg(r) => {
-                dynasm!(ctx.asm
-                    ; push Rq(r)
-                );
-            }
-            ValueLocation::Stack(offset) => {
-                let offset = adjusted_offset(ctx, offset);
-                dynasm!(ctx.asm
-                    ; push QWORD [rsp + offset]
-                );
-            }
-            ValueLocation::Immediate(imm) => {
-                dynasm!(ctx.asm
-                    ; push imm
-                );
-            }
-        }
-    }
-    // If `location` is `None` then we don't need to do anything.
+    free_return_register(ctx, 1);
+    pop_i32_into(ctx, ValueLocation::Reg(RAX))
 }
 
 pub fn push_block_return_value(ctx: &mut Context) {
-    ctx.block_state.depth.reserve(1);
-    ctx.block_state.stack.push(StackValue::Pop);
+    ctx.block_state.stack.push(StackValue::Temp(RAX));
 }
 
-pub fn restore_block_state(ctx: &mut Context, block_state: BlockState) {
-    ctx.block_state = block_state;
+pub fn end_block(ctx: &mut Context, parent_block_state: BlockState) {
+    restore_locals(ctx);
+    ctx.block_state = parent_block_state;
 }
 
 pub fn push_return_value(ctx: &mut Context) {
     ctx.block_state.stack.push(StackValue::Temp(RAX));
+}
+
+fn restore_locals(ctx: &mut Context) {
+    for (src, dst) in ctx
+        .block_state
+        .locals
+        .register_arguments
+        .clone()
+        .iter()
+        .zip(&ctx.original_locals.register_arguments.clone())
+    {
+        copy_value(ctx, *src, *dst);
+    }
 }
 
 fn push_i32(ctx: &mut Context, value: Value) {
@@ -443,7 +455,8 @@ fn pop_i32_into(ctx: &mut Context, dst: ValueLocation) {
         }
     };
 
-    let src = to_move.location(&ctx.locals);
+    let src = to_move.location(&ctx.block_state.locals);
+    println!("{:?}, {:?}", src, dst);
     copy_value(ctx, src, dst);
     free_val(ctx, to_move);
 }
@@ -457,7 +470,7 @@ fn free_val(ctx: &mut Context, val: Value) {
 
 /// Puts this value into a register so that it can be efficiently read
 fn into_reg(ctx: &mut Context, val: Value) -> GPR {
-    match val.location(&ctx.locals) {
+    match val.location(&ctx.block_state.locals) {
         ValueLocation::Stack(offset) => {
             let offset = adjusted_offset(ctx, offset);
             let scratch = ctx.block_state.regs.take_scratch_gpr();
@@ -484,7 +497,7 @@ fn into_temp_reg(ctx: &mut Context, val: Value) -> GPR {
         Value::Local(loc) => {
             let scratch = ctx.block_state.regs.take_scratch_gpr();
 
-            match local_location(&ctx.locals, loc) {
+            match ctx.block_state.locals.get(loc) {
                 ValueLocation::Stack(offset) => {
                     let offset = adjusted_offset(ctx, offset);
                     dynasm!(ctx.asm
@@ -534,7 +547,7 @@ macro_rules! commutative_binop {
                 _ => (into_temp_reg(ctx, op0), op1),
             };
 
-            match op0.location(&ctx.locals) {
+            match op0.location(&ctx.block_state.locals) {
                 ValueLocation::Reg(reg) => {
                     dynasm!(ctx.asm
                         ; $instr Rd(op1), Rd(reg)
@@ -560,12 +573,14 @@ macro_rules! commutative_binop {
     }
 }
 
-commutative_binop!(i32_add, add, |a, b| a + b);
+commutative_binop!(i32_add, add, i32::wrapping_add);
 commutative_binop!(i32_and, and, |a, b| a & b);
 commutative_binop!(i32_or, or, |a, b| a | b);
 commutative_binop!(i32_xor, xor, |a, b| a ^ b);
-commutative_binop!(i32_mul, imul, |a, b| a * b);
+commutative_binop!(i32_mul, imul, i32::wrapping_mul);
 
+// `sub` is not commutative, so we have to handle it differently (we _must_ use the `op1`
+// temp register as the output)
 pub fn i32_sub(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
     let op1 = pop_i32(ctx);
@@ -578,7 +593,7 @@ pub fn i32_sub(ctx: &mut Context) {
     }
 
     let op1 = into_temp_reg(ctx, op1);
-    match op0.location(&ctx.locals) {
+    match op0.location(&ctx.block_state.locals) {
         ValueLocation::Reg(reg) => {
             dynasm!(ctx.asm
                 ; sub Rd(op1), Rd(reg)
@@ -610,8 +625,18 @@ pub fn get_local_i32(ctx: &mut Context, local_idx: u32) {
 //       back into registers here.
 pub fn set_local_i32(ctx: &mut Context, local_idx: u32) {
     let val = pop_i32(ctx);
-    let val_loc = val.location(&ctx.locals);
-    let dst_loc = local_location(&ctx.locals, local_idx);
+    let val_loc = val.location(&ctx.block_state.locals);
+    let dst_loc = ctx.original_locals.get(local_idx);
+
+    if let Some(cur) = ctx
+        .block_state
+        .locals
+        .register_arguments
+        .get_mut(local_idx as usize)
+    {
+        *cur = dst_loc;
+    }
+
     copy_value(ctx, val_loc, dst_loc);
     free_val(ctx, val);
 }
@@ -626,7 +651,7 @@ pub fn relop_eq_i32(ctx: &mut Context) {
     let result = ctx.block_state.regs.take_scratch_gpr();
 
     if let Some(i) = left.immediate() {
-        match right.location(&ctx.locals) {
+        match right.location(&ctx.block_state.locals) {
             ValueLocation::Stack(offset) => {
                 let offset = adjusted_offset(ctx, offset);
                 dynasm!(ctx.asm
@@ -651,7 +676,7 @@ pub fn relop_eq_i32(ctx: &mut Context) {
         }
     } else {
         let lreg = into_reg(ctx, left);
-        match right.location(&ctx.locals) {
+        match right.location(&ctx.block_state.locals) {
             ValueLocation::Stack(offset) => {
                 let offset = adjusted_offset(ctx, offset);
                 dynasm!(ctx.asm
@@ -755,7 +780,7 @@ fn copy_value(ctx: &mut Context, src: ValueLocation, dst: ValueLocation) {
 
 #[must_use]
 pub struct CallCleanup {
-    restore_registers: Vec<GPR>,
+    restore_registers: ArrayVec<[GPR; SCRATCH_REGS.len()]>,
     stack_depth: i32,
 }
 
@@ -770,15 +795,16 @@ fn free_arg_registers(ctx: &mut Context, count: u32) {
         return;
     }
 
-    for i in 0..ctx.locals.locs.len() {
-        match ctx.locals.locs[i] {
+    // This is bound to the maximum size of the `ArrayVec` amd so preserves linear runtime
+    for i in 0..ctx.block_state.locals.register_arguments.len() {
+        match ctx.block_state.locals.register_arguments[i] {
             ValueLocation::Reg(reg) => {
                 if ARGS_IN_GPRS.contains(&reg) {
                     let offset = adjusted_offset(ctx, (i as u32 * WORD_SIZE) as _);
                     dynasm!(ctx.asm
                         ; mov [rsp + offset], Rq(reg)
                     );
-                    ctx.locals.locs[i] = ValueLocation::Stack(offset);
+                    ctx.block_state.locals.register_arguments[i] = ValueLocation::Stack(offset);
                 }
             }
             _ => {}
@@ -792,7 +818,7 @@ fn free_return_register(ctx: &mut Context, count: u32) {
     }
 
     for stack_val in &mut ctx.block_state.stack {
-        match stack_val.location(&ctx.locals) {
+        match stack_val.location(&ctx.block_state.locals) {
             // For now it's impossible for a local to be in RAX but that might be
             // possible in the future, so we check both cases.
             Some(ValueLocation::Reg(RAX)) => {
@@ -809,8 +835,8 @@ fn free_return_register(ctx: &mut Context, count: u32) {
 
 // TODO: Use `ArrayVec`?
 /// Saves volatile (i.e. caller-saved) registers before a function call, if they are used.
-fn save_volatile(ctx: &mut Context) -> Vec<GPR> {
-    let mut out = vec![];
+fn save_volatile(ctx: &mut Context) -> ArrayVec<[GPR; SCRATCH_REGS.len()]> {
+    let mut out = ArrayVec::new();
 
     // TODO: If there are no `StackValue::Pop`s that need to be popped
     //       before we reach our `Temp` value, we can set the `StackValue`
@@ -832,11 +858,6 @@ fn save_volatile(ctx: &mut Context) -> Vec<GPR> {
 /// calling convention.
 fn pass_outgoing_args(ctx: &mut Context, arity: u32) -> CallCleanup {
     let num_stack_args = (arity as usize).saturating_sub(ARGS_IN_GPRS.len()) as i32;
-
-    let out = CallCleanup {
-        stack_depth: num_stack_args,
-        restore_registers: save_volatile(ctx),
-    };
 
     // We pop stack arguments first - arguments are RTL
     if num_stack_args > 0 {
@@ -869,7 +890,10 @@ fn pass_outgoing_args(ctx: &mut Context, arity: u32) -> CallCleanup {
         pop_i32_into(ctx, ValueLocation::Reg(*reg));
     }
 
-    out
+    CallCleanup {
+        stack_depth: num_stack_args,
+        restore_registers: save_volatile(ctx),
+    }
 }
 
 /// Frees up the stack space used for stack-passed arguments and restores the value
@@ -923,29 +947,23 @@ pub fn start_function(ctx: &mut Context, arguments: u32, locals: u32) {
     // Align stack slots to the nearest even number. This is required
     // by x86-64 ABI.
     let aligned_stack_slots = (locals + 1) & !1;
-    let framesize: i32 = aligned_stack_slots as i32 * WORD_SIZE as i32;
+    let frame_size: i32 = aligned_stack_slots as i32 * WORD_SIZE as i32;
 
-    ctx.locals.locs = reg_args
-        .iter()
-        .cloned()
-        .map(ValueLocation::Reg)
-        .chain(
-            (0..arguments.saturating_sub(ARGS_IN_GPRS.len() as _))
-                // We add 2 here because 1 stack slot is used for the stack pointer and another is
-                // used for the return address. It's a magic number but there's not really a way
-                // around this.
-                .map(|arg_i| ValueLocation::Stack(((arg_i + 2) * WORD_SIZE) as i32 + framesize)),
-        )
-        .collect();
+    ctx.original_locals.register_arguments =
+        reg_args.iter().cloned().map(ValueLocation::Reg).collect();
+    ctx.original_locals.num_stack_args = arguments.saturating_sub(ARGS_IN_GPRS.len() as _);
+    ctx.original_locals.num_local_stack_slots = locals;
+    ctx.block_state.locals = ctx.original_locals.clone();
 
     dynasm!(ctx.asm
         ; push rbp
         ; mov rbp, rsp
     );
 
-    if framesize > 0 {
+    // ctx.block_state.depth.reserve(aligned_stack_slots - locals);
+    if frame_size > 0 {
         dynasm!(ctx.asm
-            ; sub rsp, framesize
+            ; sub rsp, frame_size
         );
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -503,12 +503,9 @@ pub fn prologue(ctx: &mut Context, stack_slots: u32) {
 }
 
 pub fn epilogue(ctx: &mut Context) {
-    // TODO: This doesn't work with stack alignment.
-    // assert_eq!(
-    //     ctx.sp_depth,
-    //     StackDepth(0),
-    //     "imbalanced pushes and pops detected"
-    // );
+    // We don't need to clean up the stack - `rsp` is restored and
+    // the calling function has its own register stack and will
+    // stomp on the registers from our stack if necessary.
     dynasm!(ctx.asm
         ; mov rsp, rbp
         ; pop rbp

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -182,6 +182,7 @@ impl CodeGenSession {
     }
 }
 
+#[derive(Debug)]
 pub struct TranslatedCodeSection {
     exec_buf: ExecutableBuffer,
     func_defs: Vec<AssemblyOffset>,
@@ -191,6 +192,10 @@ impl TranslatedCodeSection {
     pub fn func_start(&self, idx: usize) -> *const u8 {
         let offset = self.func_defs[idx];
         self.exec_buf.ptr(offset)
+    }
+
+    pub fn disassemble(&self) {
+        ::disassemble::disassemble(&*self.exec_buf).unwrap();
     }
 }
 
@@ -260,14 +265,64 @@ fn pop_i32(ctx: &mut Context) -> GPR {
     gpr
 }
 
-pub fn add_i32(ctx: &mut Context) {
+pub fn i32_add(ctx: &mut Context) {
     let op0 = pop_i32(ctx);
     let op1 = pop_i32(ctx);
     dynasm!(ctx.asm
-        ; add Rd(op0), Rd(op1)
+        ; add Rd(op1), Rd(op0)
     );
-    push_i32(ctx, op0);
-    ctx.regs.release_scratch_gpr(op1);
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_sub(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; sub Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_and(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; and Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_or(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; or Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_xor(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; xor Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
+}
+
+pub fn i32_mul(ctx: &mut Context) {
+    let op0 = pop_i32(ctx);
+    let op1 = pop_i32(ctx);
+    dynasm!(ctx.asm
+        ; imul Rd(op1), Rd(op0)
+    );
+    push_i32(ctx, op1);
+    ctx.regs.release_scratch_gpr(op0);
 }
 
 fn sp_relative_offset(ctx: &mut Context, slot_idx: u32) -> i32 {
@@ -433,6 +488,7 @@ pub fn call_direct(ctx: &mut Context, index: u32, arg_arity: u32, return_arity: 
 }
 
 pub fn prologue(ctx: &mut Context, stack_slots: u32) {
+    let stack_slots = stack_slots;
     // Align stack slots to the nearest even number. This is required
     // by x86-64 ABI.
     let aligned_stack_slots = (stack_slots + 1) & !1;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -344,9 +344,7 @@ pub fn current_block_state(ctx: &Context) -> BlockState {
     ctx.block_state.clone()
 }
 
-pub fn return_from_block(ctx: &mut Context, new_depth: StackDepth) {
-    let diff = ((ctx.block_state.depth.0 - new_depth.0) * WORD_SIZE) as i32;
-
+pub fn return_from_block(ctx: &mut Context) {
     if let Some(loc) = ctx.block_state.stack.last().unwrap().location(&ctx.locals) {
         match loc {
             ValueLocation::Reg(r) => {

--- a/src/disassemble.rs
+++ b/src/disassemble.rs
@@ -20,7 +20,7 @@ pub fn disassemble(mem: &[u8]) -> Result<(), Error> {
         for b in i.bytes() {
             write!(&mut bytes_str, "{:02x} ", b).unwrap();
         }
-        write!(&mut line, "{:21}\t", bytes_str).unwrap();
+        write!(&mut line, "{:24}\t", bytes_str).unwrap();
 
         if let Some(s) = i.mnemonic() {
             write!(&mut line, "{}\t", s).unwrap();

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -208,18 +208,15 @@ pub fn translate(
                     }
                 }
             }
-            Operator::I32Eq => {
-                relop_eq_i32(&mut ctx);
-            }
-            Operator::I32Add => {
-                add_i32(&mut ctx);
-            }
-            Operator::GetLocal { local_index } => {
-                get_local_i32(&mut ctx, local_index);
-            }
-            Operator::I32Const { value } => {
-                literal_i32(&mut ctx, value);
-            }
+            Operator::I32Eq => relop_eq_i32(&mut ctx),
+            Operator::I32Add => i32_add(&mut ctx),
+            Operator::I32Sub => i32_sub(&mut ctx),
+            Operator::I32And => i32_and(&mut ctx),
+            Operator::I32Or => i32_or(&mut ctx),
+            Operator::I32Xor => i32_xor(&mut ctx),
+            Operator::I32Mul => i32_mul(&mut ctx),
+            Operator::GetLocal { local_index } => get_local_i32(&mut ctx, local_index),
+            Operator::I32Const { value } => literal_i32(&mut ctx, value),
             Operator::Call { function_index } => {
                 let callee_ty = translation_ctx.func_type(function_index);
 

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -158,7 +158,7 @@ pub fn translate(
                         // 0 it will branch here.
                         // After that reset stack depth to the value before entering `if` block.
                         define_label(&mut ctx, if_not);
-                        restore_block_state(&mut ctx, block_state.clone());
+                        end_block(&mut ctx, block_state.clone());
 
                         // Carry over the `end_label`, so it will be resolved when the corresponding `end`
                         // is encountered.
@@ -199,7 +199,7 @@ pub fn translate(
                     prepare_return_value(&mut ctx);
                 }
 
-                restore_block_state(&mut ctx, control_frame.block_state);
+                end_block(&mut ctx, control_frame.block_state);
                 push_block_return_value(&mut ctx);
             }
             Operator::I32Eq => relop_eq_i32(&mut ctx),

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -148,7 +148,7 @@ pub fn translate(
                         ..
                     }) => {
                         if ty != Type::EmptyBlockType {
-                            return_from_block(&mut ctx, block_state.depth);
+                            return_from_block(&mut ctx);
                         }
 
                         // Finalize if..else block by jumping to the `end_label`.
@@ -179,7 +179,7 @@ pub fn translate(
                 let control_frame = control_frames.pop().expect("control stack is never empty");
 
                 if control_frame.ty != Type::EmptyBlockType && !control_frames.is_empty() {
-                    return_from_block(&mut ctx, control_frame.block_state.depth);
+                    return_from_block(&mut ctx);
                 }
 
                 if !control_frame.kind.is_loop() {

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -56,29 +56,20 @@ struct ControlFrame {
     /// becomes polymorphic only after an instruction that never passes control further is executed,
     /// i.e. `unreachable`, `br` (but not `br_if`!), etc.
     stack_polymorphic: bool,
-    /// Relative stack depth at the beginning of the frame.
-    stack_depth: StackDepth,
+    /// State specific to the block (free temp registers, stack etc) which should be replaced
+    /// at the end of the block
+    block_state: BlockState,
     ty: Type,
 }
 
 impl ControlFrame {
-    pub fn new(kind: ControlFrameKind, stack_depth: StackDepth, ty: Type) -> ControlFrame {
+    pub fn new(kind: ControlFrameKind, block_state: BlockState, ty: Type) -> ControlFrame {
         ControlFrame {
             kind,
-            stack_depth,
+            block_state,
             ty,
             stack_polymorphic: false,
         }
-    }
-
-    pub fn outgoing_stack_depth(&self) -> StackDepth {
-        let mut outgoing_stack_depth = self.stack_depth;
-        if self.ty != Type::EmptyBlockType {
-            // If there a return value then reserve expected outgoing stack depth value
-            // to account for the result value.
-            outgoing_stack_depth.reserve(1);
-        }
-        outgoing_stack_depth
     }
 
     /// Marks this control frame as reached stack-polymorphic state.
@@ -103,20 +94,16 @@ pub fn translate(
         Type::EmptyBlockType
     };
 
-    let mut framesize = arg_count;
+    let mut num_locals = 0;
     for local in locals {
         let (count, _ty) = local?;
-        framesize += count;
+        num_locals += count;
     }
 
     let mut ctx = session.new_context(func_idx);
     let operators = body.get_operators_reader()?;
 
-    prologue(&mut ctx, framesize);
-
-    for arg_pos in 0..arg_count {
-        copy_incoming_arg(&mut ctx, framesize, arg_pos);
-    }
+    start_function(&mut ctx, arg_count, num_locals);
 
     let mut control_frames = Vec::new();
 
@@ -127,7 +114,7 @@ pub fn translate(
         ControlFrameKind::Block {
             end_label: epilogue_label,
         },
-        current_stack_depth(&ctx),
+        current_block_state(&ctx),
         return_ty,
     ));
 
@@ -148,7 +135,7 @@ pub fn translate(
 
                 control_frames.push(ControlFrame::new(
                     ControlFrameKind::IfTrue { end_label, if_not },
-                    current_stack_depth(&ctx),
+                    current_block_state(&ctx),
                     ty,
                 ));
             }
@@ -157,7 +144,7 @@ pub fn translate(
                     Some(ControlFrame {
                         kind: ControlFrameKind::IfTrue { if_not, end_label },
                         ty,
-                        stack_depth,
+                        block_state,
                         ..
                     }) => {
                         // Finalize if..else block by jumping to the `end_label`.
@@ -167,7 +154,7 @@ pub fn translate(
                         // 0 it will branch here.
                         // After that reset stack depth to the value before entering `if` block.
                         define_label(&mut ctx, if_not);
-                        restore_stack_depth(&mut ctx, stack_depth);
+                        restore_block_state(&mut ctx, block_state.clone());
 
                         // Carry over the `end_label`, so it will be resolved when the corresponding `end`
                         // is encountered.
@@ -175,7 +162,7 @@ pub fn translate(
                         // Also note that we reset `stack_depth` to the value before entering `if` block.
                         let mut frame = ControlFrame::new(
                             ControlFrameKind::IfFalse { end_label },
-                            stack_depth,
+                            block_state,
                             ty,
                         );
                         control_frames.push(frame);
@@ -199,14 +186,12 @@ pub fn translate(
                     define_label(&mut ctx, if_not);
                 }
 
-                restore_stack_depth(&mut ctx, control_frame.outgoing_stack_depth());
-
-                if control_frames.len() == 0 {
-                    // This is the last control frame. Perform the implicit return here.
-                    if return_ty != Type::EmptyBlockType {
-                        prepare_return_value(&mut ctx);
-                    }
+                // This is the last control frame. Perform the implicit return here.
+                if control_frames.len() == 0 && return_ty != Type::EmptyBlockType {
+                    prepare_return_value(&mut ctx);
                 }
+
+                // restore_block_state(&mut ctx, control_frame.block_state);
             }
             Operator::I32Eq => relop_eq_i32(&mut ctx),
             Operator::I32Add => i32_add(&mut ctx),
@@ -229,6 +214,7 @@ pub fn translate(
                     callee_ty.params.len() as u32,
                     callee_ty.returns.len() as u32,
                 );
+                push_return_value(&mut ctx);
             }
             _ => {
                 trap(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -226,8 +226,12 @@ pub fn translate(
                 // TODO: this implementation assumes that this function is locally defined.
                 // TODO: guarantee 16-byte alignment for calls as required by x86-64 ABI
 
-                pass_outgoing_args(&mut ctx, callee_ty.params.len() as u32);
-                call_direct(&mut ctx, function_index, callee_ty.returns.len() as u32);
+                call_direct(
+                    &mut ctx,
+                    function_index,
+                    callee_ty.params.len() as u32,
+                    callee_ty.returns.len() as u32,
+                );
             }
             _ => {
                 trap(&mut ctx);

--- a/src/function_body.rs
+++ b/src/function_body.rs
@@ -115,7 +115,7 @@ pub fn translate(
     prologue(&mut ctx, framesize);
 
     for arg_pos in 0..arg_count {
-        copy_incoming_arg(&mut ctx, arg_pos);
+        copy_incoming_arg(&mut ctx, framesize, arg_pos);
     }
 
     let mut control_frames = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
-#![feature(plugin)]
+#![feature(plugin, test)]
 #![plugin(dynasm)]
+
+extern crate test;
 
 extern crate capstone;
 extern crate failure;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@ extern crate wasmparser;
 #[macro_use]
 extern crate failure_derive;
 extern crate dynasmrt;
-
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate quickcheck;
 extern crate wabt;
 
 mod backend;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,10 @@ extern crate wasmparser;
 #[macro_use]
 extern crate failure_derive;
 extern crate dynasmrt;
+#[cfg(test)]
 #[macro_use]
 extern crate lazy_static;
+#[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
 extern crate wabt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
-#![feature(plugin, test)]
+#![feature(plugin, test, const_slice_len)]
 #![plugin(dynasm)]
 
 extern crate test;
 
+extern crate arrayvec;
 extern crate capstone;
 extern crate failure;
 extern crate wasmparser;

--- a/src/module.rs
+++ b/src/module.rs
@@ -52,6 +52,13 @@ impl TranslatedModule {
 
         args.call(start_buf)
     }
+
+    pub fn disassemble(&self) {
+        self.translated_code_section
+            .as_ref()
+            .expect("no code section")
+            .disassemble();
+    }
 }
 
 #[derive(Default)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -317,17 +317,23 @@ const FIBONACCI: &str = r#"
 
 #[test]
 fn fib() {
-    // fac(x) = y <=> (x, y)
-    const FIB_SEQ: &[u32] = &[1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
+    fn fib(n: u32) -> u32 {
+        let (mut a, mut b) = (1, 1);
+
+        for _ in 0..n {
+            let old_a = a;
+            a = b;
+            b += old_a;
+        }
+
+        a
+    }
 
     let translated = translate_wat(FIBONACCI);
 
-    for x in 0..10 {
+    for x in 0..30 {
         unsafe {
-            assert_eq!(
-                translated.execute_func::<_, u32>(0, (x,)),
-                FIB_SEQ[x as usize]
-            );
+            assert_eq!(translated.execute_func::<_, u32>(0, (x,)), fib(x));
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -259,7 +259,8 @@ fn function_write_args_spill_to_stack() {
     assert_eq!(
         {
             let translated = translate_wat(code);
-            let out: u32 = unsafe { translated.execute_func(0, (11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)) };
+            let out: u32 =
+                unsafe { translated.execute_func(0, (11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)) };
             out
         },
         11

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -250,6 +250,7 @@ fn function_write_args_spill_to_stack() {
     assert_eq!(
         {
             let translated = translate_wat(code);
+            translated.disassemble();
             let out: u32 =
                 unsafe { translated.execute_func(0, (11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)) };
             out
@@ -330,6 +331,7 @@ fn fib() {
     }
 
     let translated = translate_wat(FIBONACCI);
+    translated.disassemble();
 
     for x in 0..30 {
         unsafe {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -272,7 +272,7 @@ fn literals() {
 
 const FIBONACCI: &str = r#"
 (module
-  (func $fib (param $n i32) (param $_unused i32) (result i32)
+  (func $fib (param $n i32) (result i32)
     (if (result i32)
       (i32.eq
         (i32.const 0)
@@ -298,7 +298,6 @@ const FIBONACCI: &str = r#"
                   (get_local $n)
                   (i32.const -1)
                 )
-                (i32.const 0)
               )
               ;; fib(n - 2)
               (call $fib
@@ -306,7 +305,6 @@ const FIBONACCI: &str = r#"
                   (get_local $n)
                   (i32.const -2)
                 )
-                (i32.const 0)
               )
             )
           )
@@ -327,7 +325,7 @@ fn fib() {
     for x in 0..10 {
         unsafe {
             assert_eq!(
-                translated.execute_func::<_, u32>(0, (x, 0u32)),
+                translated.execute_func::<_, u32>(0, (x,)),
                 FIB_SEQ[x as usize]
             );
         }
@@ -346,5 +344,5 @@ fn bench_run(b: &mut test::Bencher) {
     let wasm = wabt::wat2wasm(FIBONACCI).unwrap();
     let module = translate(&wasm).unwrap();
 
-    b.iter(|| unsafe { module.execute_func::<_, u32>(0, (20, 0u32)) });
+    b.iter(|| unsafe { module.execute_func::<_, u32>(0, (20,)) });
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -201,7 +201,9 @@ fn function_read_args_spill_to_stack() {
     assert_eq!(
         {
             let translated = translate_wat(code);
-            let out: u32 = unsafe { translated.execute_func(0, (7, 6, 5, 4, 3, 2, 1, 0)) };
+            let out: u32 = unsafe {
+                translated.execute_func(0, (7u32, 6u32, 5u32, 4u32, 3u32, 2u32, 1u32, 0u32))
+            };
             out
         },
         7
@@ -214,6 +216,7 @@ fn function_write_args_spill_to_stack() {
 (module
   (func (param i32) (param i32) (param i32) (param i32)
         (param i32) (param i32) (param i32) (param i32)
+        (param i32) (param i32) (param i32) (param i32)
         (result i32)
 
     (call $called
@@ -225,16 +228,21 @@ fn function_write_args_spill_to_stack() {
       (get_local 5)
       (get_local 6)
       (get_local 7)
+      (get_local 8)
+      (get_local 9)
+      (get_local 10)
+      (get_local 11)
     )
   )
 
   (func $called
         (param i32) (param i32) (param i32) (param i32)
         (param i32) (param i32) (param i32) (param i32)
+        (param i32) (param i32) (param i32) (param i32)
         (result i32)
 
     (call $assert_zero
-      (get_local 7)
+      (get_local 11)
     )
     (get_local 0)
   )
@@ -251,10 +259,10 @@ fn function_write_args_spill_to_stack() {
     assert_eq!(
         {
             let translated = translate_wat(code);
-            let out: u32 = unsafe { translated.execute_func(0, (7, 6, 5, 4, 3, 2, 1, 0)) };
+            let out: u32 = unsafe { translated.execute_func(0, (11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)) };
             out
         },
-        7
+        11
     );
 }
 #[test]


### PR DESCRIPTION
Second attempt at implementing on-the-fly register allocation. This is based on #9 and should not be merged before that PR. All my code for this PR is in these commits: https://github.com/CraneStation/lightbeam/pull/12/files/7b7a1123bc7ec373584c6ddb64054e02356908c0..679bbc56dbbdddf24c3ad0046bc0a86fac0b63fc.

This work massively reduces the unnecessary shuffling to/from stack and between registers that we see in the existing code, and makes some things way more efficient (like comparing against a literal or adding a literal, for example). It replaces taking and returning `GPR` types in many places with `Value` types, which can represent a local (either in a register or on the stack). It also means that we no longer have to copy arguments onto the stack in the prelude before working on them. This change changes the meaning of some types and adds some invariants. For example, `ValueLocation::Stack` is no longer an absolute offset, it's an offset were the stack depth 0. This is because the `ValueLocation`s stored in `ctx.local` are long-lived and it's easier to have a single `ValueLocation` than one `RelativeValueLocation` and one `AbsoluteValueLocation` imo.

I've commented the code but I can add more comments if necessary.

Benchcmp results:

```
 name                  preopt.bench ns/iter  postopt.bench ns/iter  diff ns/iter   diff %  speedup 
 tests::bench_compile  9,479                 13,835                        4,356   45.95%   x 0.69 
 tests::bench_run      135,178               55,826                      -79,352  -58.70%   x 2.42 
```

The compilation time got slower just in the last couple of commits, before that it was achieving 50% speedup with almost no difference in compile time. I think it would be easily possible to get back to the original compilation speed with a small amount of effort given to optimisation.