### PR TITLE
microwasm: fix comment typo for BrIf

### DIFF
--- a/src/microwasm.rs
+++ b/src/microwasm.rs
@@ -458,8 +458,8 @@ pub enum Operator<Label> {
         /// Returning from the function is just calling the "return" block
         target: BrTarget<Label>,
     },
-    /// Pop a value off the top of the stack, jump to the `else_` label if this value is `true`
-    /// and the `then` label otherwise. The `then` and `else_` blocks must have the same parameters.
+    /// Pop a value off the top of the stack, jump to the `then` label if this value is `true`
+    /// and the `else_` label otherwise. The `then` and `else_` blocks must have the same parameters.
     BrIf {
         /// Label to jump to if the value at the top of the stack is true
         then: BrTargetDrop<Label>,


### PR DESCRIPTION
I read the [blogpost series](http://troubles.md/posts/wasm-is-not-a-stack-machine/) leading to microwasm and found this little typo while diving into the code.

Awesome work by the way! I just find Rust very difficult to grasp, so I'm looking forward to more docs/blogposts about microwasm so it can benefit other implementors :)