### PR TITLE
Fix for ctz and clz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rusty-tags.*
 docs/_build
 *~
 \#*\#
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ rusty-tags.*
 docs/_build
 *~
 \#*\#
-.vscode

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3236,7 +3236,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let out_val = match val {
             ValueLocation::Immediate(imm) =>
                 ValueLocation::Immediate(
-                    ((imm.as_int().unwrap() as i32).leading_zeros() as i32).into()
+                    imm.as_i32().unwrap().leading_zeros().into()
                 ),
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
@@ -3250,6 +3250,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                     ; mov Rd(temp_2.rq().unwrap()), DWORD 0x1fu64 as _
                     ; xor Rd(temp.rq().unwrap()), Rd(temp_2.rq().unwrap())
                 );
+                self.free_value(ValueLocation::Reg(temp_2));
                 ValueLocation::Reg(temp)
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
@@ -3277,7 +3278,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let out_val = match val {
             ValueLocation::Immediate(imm) =>
                 ValueLocation::Immediate(
-                    ((imm.as_int().unwrap() as u64).leading_zeros() as u64).into()
+                    imm.as_i64().unwrap().leading_zeros().into()
                 ),
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
@@ -3291,6 +3292,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                     ; mov Rq(temp_2.rq().unwrap()), QWORD 0x3fu64 as _
                     ; xor Rq(temp.rq().unwrap()), Rq(temp_2.rq().unwrap())
                 );
+                self.free_value(ValueLocation::Reg(temp_2));
                 ValueLocation::Reg(temp)
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
@@ -3318,7 +3320,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let out_val = match val {
             ValueLocation::Immediate(imm) =>
                 ValueLocation::Immediate(
-                    ((imm.as_int().unwrap() as u32).trailing_zeros() as u32).into()
+                    imm.as_i32().unwrap().trailing_zeros().into()
                 ),
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
@@ -3330,6 +3332,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                     ; mov Rd(temp_zero_val.rq().unwrap()), DWORD 0x20u32 as _
                     ; cmove Rd(temp.rq().unwrap()), Rd(temp_zero_val.rq().unwrap())
                 );
+                self.free_value(ValueLocation::Reg(temp_zero_val));
                 ValueLocation::Reg(temp)
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
@@ -3355,7 +3358,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let out_val = match val {
             ValueLocation::Immediate(imm) =>
                 ValueLocation::Immediate(
-                    ((imm.as_int().unwrap() as u64).trailing_zeros() as u64).into()
+                    imm.as_i64().unwrap().trailing_zeros().into()
                 ),
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
@@ -3367,6 +3370,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                     ; mov Rq(temp_zero_val.rq().unwrap()), QWORD 0x40u64 as _
                     ; cmove Rq(temp.rq().unwrap()), Rq(temp_zero_val.rq().unwrap())
                 );
+                self.free_value(ValueLocation::Reg(temp_zero_val));
                 ValueLocation::Reg(temp)
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3241,30 +3241,46 @@ impl<'this, M: ModuleContext> Context<'this, M> {
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I32).unwrap();
-                let temp_2 = self.take_reg(I32).unwrap();
+                
 
-                dynasm!(self.asm
-                    ; bsr Rd(temp.rq().unwrap()), [rsp + offset]
-                    ; mov Rd(temp_2.rq().unwrap()), DWORD 0x3fu64 as _
-                    ; cmove Rd(temp.rq().unwrap()), Rd(temp_2.rq().unwrap())
-                    ; mov Rd(temp_2.rq().unwrap()), DWORD 0x1fu64 as _
-                    ; xor Rd(temp.rq().unwrap()), Rd(temp_2.rq().unwrap())
-                );
-                self.free_value(ValueLocation::Reg(temp_2));
-                ValueLocation::Reg(temp)
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; lzcnt Rd(temp.rq().unwrap()), [rsp + offset]
+                    );
+                    ValueLocation::Reg(temp)
+                } else {
+                    let temp_2 = self.take_reg(I32).unwrap();
+
+                    dynasm!(self.asm
+                        ; bsr Rd(temp.rq().unwrap()), [rsp + offset]
+                        ; mov Rd(temp_2.rq().unwrap()), DWORD 0x3fu64 as _
+                        ; cmove Rd(temp.rq().unwrap()), Rd(temp_2.rq().unwrap())
+                        ; mov Rd(temp_2.rq().unwrap()), DWORD 0x1fu64 as _
+                        ; xor Rd(temp.rq().unwrap()), Rd(temp_2.rq().unwrap())
+                    );
+                    self.free_value(ValueLocation::Reg(temp_2));
+                    ValueLocation::Reg(temp)
+                }
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
                 let reg = self.into_reg(GPRType::Rq, val).unwrap();
                 let temp = self.take_reg(I32).unwrap();
 
-                dynasm!(self.asm
-                    ; bsr Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
-                    ; mov Rd(reg.rq().unwrap()), DWORD 0x3fu64 as _
-                    ; cmove Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
-                    ; mov Rd(reg.rq().unwrap()), DWORD 0x1fu64 as _
-                    ; xor Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
-                );
-                ValueLocation::Reg(temp)
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; lzcnt Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                    );
+                    ValueLocation::Reg(temp)
+                } else {
+                    dynasm!(self.asm
+                        ; bsr Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                        ; mov Rd(reg.rq().unwrap()), DWORD 0x3fu64 as _
+                        ; cmove Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                        ; mov Rd(reg.rq().unwrap()), DWORD 0x1fu64 as _
+                        ; xor Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                    );
+                    ValueLocation::Reg(temp)
+                }
             }
         };
 
@@ -3283,30 +3299,45 @@ impl<'this, M: ModuleContext> Context<'this, M> {
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I64).unwrap();
-                let temp_2 = self.take_reg(I64).unwrap();
 
-                dynasm!(self.asm
-                    ; bsr Rq(temp.rq().unwrap()), [rsp + offset]
-                    ; mov Rq(temp_2.rq().unwrap()), QWORD 0x7fu64 as _
-                    ; cmove Rq(temp.rq().unwrap()), Rq(temp_2.rq().unwrap())
-                    ; mov Rq(temp_2.rq().unwrap()), QWORD 0x3fu64 as _
-                    ; xor Rq(temp.rq().unwrap()), Rq(temp_2.rq().unwrap())
-                );
-                self.free_value(ValueLocation::Reg(temp_2));
-                ValueLocation::Reg(temp)
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; lzcnt Rq(temp.rq().unwrap()), [rsp + offset]
+                    );
+                    ValueLocation::Reg(temp)
+                } else {
+                    let temp_2 = self.take_reg(I64).unwrap();
+
+                    dynasm!(self.asm
+                        ; bsr Rq(temp.rq().unwrap()), [rsp + offset]
+                        ; mov Rq(temp_2.rq().unwrap()), QWORD 0x7fu64 as _
+                        ; cmove Rq(temp.rq().unwrap()), Rq(temp_2.rq().unwrap())
+                        ; mov Rq(temp_2.rq().unwrap()), QWORD 0x3fu64 as _
+                        ; xor Rq(temp.rq().unwrap()), Rq(temp_2.rq().unwrap())
+                    );
+                    self.free_value(ValueLocation::Reg(temp_2));
+                    ValueLocation::Reg(temp)
+                }
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
                 let reg = self.into_reg(GPRType::Rq, val).unwrap();
                 let temp = self.take_reg(I64).unwrap();
 
-                dynasm!(self.asm
-                    ; bsr Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
-                    ; mov Rq(reg.rq().unwrap()), QWORD 0x7fu64 as _
-                    ; cmove Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
-                    ; mov Rq(reg.rq().unwrap()), QWORD 0x3fu64 as _
-                    ; xor Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
-                );
-                ValueLocation::Reg(temp)
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; lzcnt Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
+                    );
+                    ValueLocation::Reg(temp)
+                } else { 
+                    dynasm!(self.asm
+                        ; bsr Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
+                        ; mov Rq(reg.rq().unwrap()), QWORD 0x7fu64 as _
+                        ; cmove Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
+                        ; mov Rq(reg.rq().unwrap()), QWORD 0x3fu64 as _
+                        ; xor Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
+                    );
+                    ValueLocation::Reg(temp)
+                }
             }
         };
 
@@ -3325,26 +3356,41 @@ impl<'this, M: ModuleContext> Context<'this, M> {
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I32).unwrap();
-                let temp_zero_val = self.take_reg(I32).unwrap();
 
-                dynasm!(self.asm
-                    ; bsf Rd(temp.rq().unwrap()), [rsp + offset]
-                    ; mov Rd(temp_zero_val.rq().unwrap()), DWORD 0x20u32 as _
-                    ; cmove Rd(temp.rq().unwrap()), Rd(temp_zero_val.rq().unwrap())
-                );
-                self.free_value(ValueLocation::Reg(temp_zero_val));
-                ValueLocation::Reg(temp)
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; tzcnt Rd(temp.rq().unwrap()), [rsp + offset]
+                    );
+                    ValueLocation::Reg(temp)
+                } else {
+                    let temp_zero_val = self.take_reg(I32).unwrap();
+
+                    dynasm!(self.asm
+                        ; bsf Rd(temp.rq().unwrap()), [rsp + offset]
+                        ; mov Rd(temp_zero_val.rq().unwrap()), DWORD 0x20u32 as _
+                        ; cmove Rd(temp.rq().unwrap()), Rd(temp_zero_val.rq().unwrap())
+                    );
+                    self.free_value(ValueLocation::Reg(temp_zero_val));
+                    ValueLocation::Reg(temp)
+                }
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
                 let reg = self.into_reg(GPRType::Rq, val).unwrap();
                 let temp = self.take_reg(I32).unwrap();
 
-                dynasm!(self.asm
-                    ; bsf Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
-                    ; mov Rd(reg.rq().unwrap()), DWORD 0x20u32 as _
-                    ; cmove Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
-                );
-                ValueLocation::Reg(temp)
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; tzcnt Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                    );
+                    ValueLocation::Reg(temp)
+                } else {
+                    dynasm!(self.asm
+                        ; bsf Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                        ; mov Rd(reg.rq().unwrap()), DWORD 0x20u32 as _
+                        ; cmove Rd(temp.rq().unwrap()), Rd(reg.rq().unwrap())
+                    );
+                    ValueLocation::Reg(temp)
+                }
             }
         };
 
@@ -3363,15 +3409,25 @@ impl<'this, M: ModuleContext> Context<'this, M> {
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I64).unwrap();
-                let temp_zero_val = self.take_reg(I64).unwrap();
+                
+                if is_x86_feature_detected!("lzcnt") {
+                    dynasm!(self.asm
+                        ; tzcnt Rq(temp.rq().unwrap()), [rsp + offset]
+                    );
+                    ValueLocation::Reg(temp)
+                } else {
+                    let temp_zero_val = self.take_reg(I64).unwrap();
 
-                dynasm!(self.asm
-                    ; bsf Rq(temp.rq().unwrap()), [rsp + offset]
-                    ; mov Rq(temp_zero_val.rq().unwrap()), QWORD 0x40u64 as _
-                    ; cmove Rq(temp.rq().unwrap()), Rq(temp_zero_val.rq().unwrap())
-                );
-                self.free_value(ValueLocation::Reg(temp_zero_val));
-                ValueLocation::Reg(temp)
+                    dynasm!(self.asm
+                        ; bsf Rq(temp.rq().unwrap()), [rsp + offset]
+                        ; mov Rq(temp_zero_val.rq().unwrap()), QWORD 0x40u64 as _
+                        ; cmove Rq(temp.rq().unwrap()), Rq(temp_zero_val.rq().unwrap())
+                    );
+                    self.free_value(ValueLocation::Reg(temp_zero_val));
+                    ValueLocation::Reg(temp)
+                }
+
+                
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
                 let reg = self.into_reg(GPRType::Rq, val).unwrap();

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3234,14 +3234,12 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let val = self.pop();
 
         let out_val = match val {
-            ValueLocation::Immediate(imm) =>
-                ValueLocation::Immediate(
-                    imm.as_i32().unwrap().leading_zeros().into()
-                ),
+            ValueLocation::Immediate(imm) => {
+                ValueLocation::Immediate(imm.as_i32().unwrap().leading_zeros().into())
+            }
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I32).unwrap();
-                
 
                 if is_x86_feature_detected!("lzcnt") {
                     dynasm!(self.asm
@@ -3292,10 +3290,9 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let val = self.pop();
 
         let out_val = match val {
-            ValueLocation::Immediate(imm) =>
-                ValueLocation::Immediate(
-                    imm.as_i64().unwrap().leading_zeros().into()
-                ),
+            ValueLocation::Immediate(imm) => {
+                ValueLocation::Immediate(imm.as_i64().unwrap().leading_zeros().into())
+            }
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I64).unwrap();
@@ -3328,7 +3325,7 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                         ; lzcnt Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
                     );
                     ValueLocation::Reg(temp)
-                } else { 
+                } else {
                     dynasm!(self.asm
                         ; bsr Rq(temp.rq().unwrap()), Rq(reg.rq().unwrap())
                         ; mov Rq(reg.rq().unwrap()), QWORD 0x7fu64 as _
@@ -3349,10 +3346,9 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let val = self.pop();
 
         let out_val = match val {
-            ValueLocation::Immediate(imm) =>
-                ValueLocation::Immediate(
-                    imm.as_i32().unwrap().trailing_zeros().into()
-                ),
+            ValueLocation::Immediate(imm) => {
+                ValueLocation::Immediate(imm.as_i32().unwrap().trailing_zeros().into())
+            }
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I32).unwrap();
@@ -3402,14 +3398,13 @@ impl<'this, M: ModuleContext> Context<'this, M> {
         let val = self.pop();
 
         let out_val = match val {
-            ValueLocation::Immediate(imm) =>
-                ValueLocation::Immediate(
-                    imm.as_i64().unwrap().trailing_zeros().into()
-                ),
+            ValueLocation::Immediate(imm) => {
+                ValueLocation::Immediate(imm.as_i64().unwrap().trailing_zeros().into())
+            }
             ValueLocation::Stack(offset) => {
                 let offset = self.adjusted_offset(offset);
                 let temp = self.take_reg(I64).unwrap();
-                
+
                 if is_x86_feature_detected!("lzcnt") {
                     dynasm!(self.asm
                         ; tzcnt Rq(temp.rq().unwrap()), [rsp + offset]
@@ -3426,8 +3421,6 @@ impl<'this, M: ModuleContext> Context<'this, M> {
                     self.free_value(ValueLocation::Reg(temp_zero_val));
                     ValueLocation::Reg(temp)
                 }
-
-                
             }
             ValueLocation::Reg(_) | ValueLocation::Cond(_) => {
                 let reg = self.into_reg(GPRType::Rq, val).unwrap();
@@ -5482,4 +5475,3 @@ impl IntoLabel for (LabelValue, LabelValue) {
         Box::new(const_values(self.0, self.1))
     }
 }
-


### PR DESCRIPTION
Closes #21

Ideally we should detect if a machine supports `tzcnt` and `lzcnt` correctly and use those instead when possible.