### PR TITLE
Reformat code with new rustfmt

### DIFF
--- a/src/microwasm.rs
+++ b/src/microwasm.rs
@@ -1174,12 +1174,8 @@ where
                 sig!((ty) -> (ty))
             }
 
-            WasmOperator::GetGlobal { global_index } => {
-                sig!(() -> (self.module.global_type(*global_index).to_microwasm_type()))
-            }
-            WasmOperator::SetGlobal { global_index } => {
-                sig!((self.module.global_type(*global_index).to_microwasm_type()) -> ())
-            }
+            WasmOperator::GetGlobal { global_index } => sig!(() -> (self.module.global_type(*global_index).to_microwasm_type())),
+            WasmOperator::SetGlobal { global_index } => sig!((self.module.global_type(*global_index).to_microwasm_type()) -> ()),
 
             WasmOperator::F32Load { .. } => sig!((I32) -> (F32)),
             WasmOperator::F64Load { .. } => sig!((I32) -> (F64)),
@@ -1258,12 +1254,8 @@ where
             | WasmOperator::F64Le
             | WasmOperator::F64Ge => sig!((F64, F64) -> (I32)),
 
-            WasmOperator::I32Clz | WasmOperator::I32Ctz | WasmOperator::I32Popcnt => {
-                sig!((I32) -> (I32))
-            }
-            WasmOperator::I64Clz | WasmOperator::I64Ctz | WasmOperator::I64Popcnt => {
-                sig!((I64) -> (I64))
-            }
+            WasmOperator::I32Clz | WasmOperator::I32Ctz | WasmOperator::I32Popcnt => sig!((I32) -> (I32)),
+            WasmOperator::I64Clz | WasmOperator::I64Ctz | WasmOperator::I64Popcnt => sig!((I64) -> (I64)),
 
             WasmOperator::I32Add
             | WasmOperator::I32Sub


### PR DESCRIPTION
Today new Rust version has been released and it has affected the rustfmt. It causes CI rustfmt check to fail in Wasmtime repository (lightbeam is a git submodule there).